### PR TITLE
Changed stale offset error message, fixed bug that caused snapshot to be retaken

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ in specific columns.
 - [Data change events](#data-change-events)
 - [Data type mappings](#data-type-mappings)
 - [Connector properties](#connector-properties)
+- [Frequently asked question](#frequently-asked-questions)
 
 <!--TODO add compatibility information-->
 
@@ -546,3 +547,21 @@ therefore rarely need to be specified in the connector’s configuration.
 | sourceinfo.struct.maker                | SingleStoreSourceInfoStructMaker | The name of the SourceInfoStructMaker Class that returns the SourceInfo schema and struct.                                                                                                                                                                                                                                                                                                                                                                                                                              
 | notification.sink.topic.name           |                                  | The name of the topic for the notifications. This property is required if the 'sink' is in the list of enabled channels.                                                                                                                                                                                                                                                                                                                                                                                                
 | post.processors                        |                                  | Optional list of post processors. The processors are defined using the `<post.processor.prefix>.type` option and configured using `<post.processor.prefix.<option>`.                                                                                                                                                                                                                                                                                                                                                    
+
+# Frequently asked questions
+
+## Connector Unable to Start
+A connector that is stopped for a long period fails to start, and reports the following exception:
+```
+Offset that the connector is trying to resume from is considered stale...
+```
+The preceding exception indicates that the entry that 
+offset that the connector is trying to resume from is considered stale.
+Because of it, connector cannot resume streaming.
+You can use either of the following options to recover from the failure:
+* Delete the failed connector, and create a new connector with the same configuration but with a different connector name.
+* Pause the connector and then remove offsets, or change the offset topic.
+
+To help prevent failures related to stale offsets, you can increase following SingleStore engine variables:
+* `snapshots_to_keep` - Defines the number of snapshots to keep for backup and replication.
+* `snapshot_trigger_size` - Defines the size of transaction logs in bytes, which, when reached, triggers a snapshot that is written to disk.

--- a/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
@@ -160,7 +160,8 @@ public class SingleStoreSnapshotChangeEventSource extends
     CompletionService<SingleStoreOffsetContext> completionService = new ExecutorCompletionService<>(
         executorService);
     Queue<SingleStoreOffsetContext> offsets = new ConcurrentLinkedQueue<>();
-    for (int i = 0; i < snapshotMaxThreads; i++) {
+    offsets.add(snapshotContext.offset);
+    for (int i = 1; i < snapshotMaxThreads; i++) {
       offsets.add(copyOffset(snapshotContext));
     }
 
@@ -637,8 +638,7 @@ public class SingleStoreSnapshotChangeEventSource extends
     // found a previous offset and the earlier snapshot has completed
     if (previousOffset != null && !previousOffset.isSnapshotRunning()) {
       LOGGER.info(
-          "A previous offset indicating a completed snapshot has been found. Neither schema nor data will be snapshotted.");
-      snapshotSchema = false;
+          "A previous offset indicating a completed snapshot has been found. Only schema will be snapshotted.");
       snapshotData = false;
     } else {
       LOGGER.info("No previous offset has been found");

--- a/src/test/java/com/singlestore/debezium/IntegrationTestBase.java
+++ b/src/test/java/com/singlestore/debezium/IntegrationTestBase.java
@@ -2,6 +2,8 @@ package com.singlestore.debezium;
 
 import static org.junit.Assert.assertNotNull;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
 import io.debezium.config.Configuration;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.jdbc.JdbcConfiguration;
@@ -11,7 +13,9 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 import java.util.stream.Collectors;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -215,5 +219,19 @@ abstract class IntegrationTestBase extends AbstractConnectorTest {
 
   protected static String topicName(String suffix) {
     return TEST_SERVER + "." + suffix;
+  }
+
+  public static class TestAppender extends AppenderBase<ILoggingEvent> {
+
+    private final Stack<ILoggingEvent> events = new Stack<>();
+
+    @Override
+    protected void append(ILoggingEvent event) {
+      events.add(event);
+    }
+
+    public List<ILoggingEvent> getLog() {
+      return events;
+    }
   }
 }

--- a/src/test/java/com/singlestore/debezium/StreamingIT.java
+++ b/src/test/java/com/singlestore/debezium/StreamingIT.java
@@ -171,7 +171,7 @@ public class StreamingIT extends IntegrationTestBase {
         assertEquals(source.get("connector"), "singlestore");
         assertEquals(source.get("name"), "singlestore_topic");
         assertNotNull(source.get("ts_ms"));
-        assertEquals(source.get("snapshot"), "true");
+        assertEquals(source.get("snapshot"), "false");
         assertEquals(source.get("db"), "db");
         assertEquals(source.get("table"), "purchased");
         assertNotNull(source.get("txId"));


### PR DESCRIPTION
 - Added information on how to recover from the stale offset error to the error message.
 - Fixed bug when snapshot completion was not marked in the offset context and as a result, a snapshot was retaken
 - Changed to take schema snapshot each time as the schema is not saved and should be retrieved each time when the connector is restarted.