### PR TITLE
Used PK as key for rowstore tables

### DIFF
--- a/src/main/java/com/singlestore/debezium/SingleStoreChangeRecordEmitter.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreChangeRecordEmitter.java
@@ -43,7 +43,7 @@ public class SingleStoreChangeRecordEmitter extends
   protected void emitCreateRecord(Receiver<SingleStorePartition> receiver, TableSchema tableSchema)
       throws InterruptedException {
     Object[] newColumnValues = getNewColumnValues();
-    Struct newKey = keyFromInternalId();
+    Struct newKey = generateKey(tableSchema, newColumnValues);
     Struct newValue = tableSchema.valueFromColumnData(newColumnValues);
     Struct envelope = tableSchema.getEnvelopeSchema()
         .create(newValue, getOffset().getSourceInfo(), getClock().currentTimeAsInstant());
@@ -64,7 +64,7 @@ public class SingleStoreChangeRecordEmitter extends
     Object[] oldColumnValues = getOldColumnValues();
     Object[] newColumnValues = getNewColumnValues();
 
-    Struct newKey = keyFromInternalId();
+    Struct newKey = generateKey(tableSchema, newColumnValues);
 
     Struct newValue = tableSchema.valueFromColumnData(newColumnValues);
     Struct oldValue = tableSchema.valueFromColumnData(oldColumnValues);
@@ -99,7 +99,8 @@ public class SingleStoreChangeRecordEmitter extends
   protected void emitDeleteRecord(Receiver<SingleStorePartition> receiver, TableSchema tableSchema)
       throws InterruptedException {
     Object[] oldColumnValues = getOldColumnValues();
-    Struct newKey = keyFromInternalId();
+    Object[] newColumnValues = getNewColumnValues();
+    Struct newKey = generateKey(tableSchema, newColumnValues);
 
     Struct oldValue = tableSchema.valueFromColumnData(oldColumnValues);
 
@@ -133,6 +134,14 @@ public class SingleStoreChangeRecordEmitter extends
   @Override
   protected Object[] getNewColumnValues() {
     return after;
+  }
+
+  private Struct generateKey(TableSchema tableSchema, Object[] values) {
+    if (true) {
+      return tableSchema.keyFromColumnData(values);
+    } else {
+      return keyFromInternalId();
+    }
   }
 
   private Struct keyFromInternalId() {

--- a/src/main/java/com/singlestore/debezium/SingleStoreConnectorConfig.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreConnectorConfig.java
@@ -275,6 +275,10 @@ public class SingleStoreConnectorConfig extends RelationalDatabaseConnectorConfi
     return config.getString(DATABASE_NAME);
   }
 
+  public String tableName() {
+    return config.getString(TABLE_NAME);
+  }
+
   public String hostname() {
     return config.getString(HOSTNAME);
   }

--- a/src/main/java/com/singlestore/debezium/SingleStoreDatabaseSchema.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreDatabaseSchema.java
@@ -55,12 +55,7 @@ public class SingleStoreDatabaseSchema extends RelationalDatabaseSchema {
       throws SQLException {
     connection.readSchema(tables(), null, null, getTableFilter(), null, true);
     refreshSchemas();
-    for (TableId tableId : tableIds()) {
-      isRowstore.put(tableId, connection.isRowstoreTable(tableId));
-      tableFor(tableId).edit().addAttribute(
-          Attribute.editor().name("IS_ROWSTORE").value(connection.isRowstoreTable(tableId))
-              .create());
-    }
+
     return this;
   }
 

--- a/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
@@ -328,7 +328,8 @@ public class SingleStoreSnapshotChangeEventSource extends
             setSnapshotMarker(offset, firstTable, lastTable, rows == 1,
                 ObserveResultSetUtils.isCommitSnapshot(rs) && numPartitions == 1);
             dispatcher.dispatchSnapshotEvent(partition, table.id(),
-                getChangeRecordEmitter(partition, offset, table.id(), row, internalId,
+                getChangeRecordEmitter(partition, offset, table.id(), table, row,
+                    internalId,
                     sourceTableSnapshotTimestamp), snapshotReceiver);
           }
         }
@@ -396,11 +397,11 @@ public class SingleStoreSnapshotChangeEventSource extends
    * Returns a {@link ChangeRecordEmitter} producing the change records for the given table row.
    */
   protected ChangeRecordEmitter<SingleStorePartition> getChangeRecordEmitter(
-      SingleStorePartition partition, SingleStoreOffsetContext offset, TableId tableId,
-      Object[] row, long internalId, Instant timestamp) {
+      SingleStorePartition partition, SingleStoreOffsetContext offset, TableId tableId, Table table,
+      Object[] row, Long internalId, Instant timestamp) {
     offset.event(tableId, timestamp);
     return new SingleStoreSnapshotChangeRecordEmitter(partition, offset, row, internalId,
-        getClock(), connectorConfig);
+        getClock(), connectorConfig, table);
   }
 
   private Threads.Timer getTableScanLogTimer() {

--- a/src/main/java/com/singlestore/debezium/SingleStoreStreamingChangeEventSource.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreStreamingChangeEventSource.java
@@ -144,7 +144,8 @@ public class SingleStoreStreamingChangeEventSource implements
                             null,
                             after,
                             internalId,
-                            connectorConfig));
+                            connectorConfig,
+                            schema.tableFor(table)));
                   } catch (InterruptedException e) {
                     interrupted[0] = e;
                     break;

--- a/src/main/java/com/singlestore/debezium/SingleStoreTableSchemaBuilder.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreTableSchemaBuilder.java
@@ -1,5 +1,6 @@
 package com.singlestore.debezium;
 
+import com.singlestore.debezium.util.InternalIdUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,7 +27,6 @@ import io.debezium.schema.FieldNameSelector.FieldNamer;
 
 public class SingleStoreTableSchemaBuilder extends TableSchemaBuilder {
 
-  public static final String INTERNAL_ID = "internalId";
   private final Boolean populateInternalId;
 
   public SingleStoreTableSchemaBuilder(ValueConverterProvider valueConverterProvider,
@@ -40,49 +40,21 @@ public class SingleStoreTableSchemaBuilder extends TableSchemaBuilder {
     this.populateInternalId = populateInternalId;
   }
 
-  private Schema addInternalId(Schema s) {
-    SchemaBuilder res = SchemaBuilder.struct();
-    for (Field f : s.fields()) {
-      res.field(f.name(), f.schema());
-    }
-    res.field(INTERNAL_ID, Schema.INT64_SCHEMA);
-
-    return res.optional().build();
-  }
-
-  private final List<Column> addInternalId(List<Column> columns) {
-    List<Column> result = new ArrayList<>(columns);
-    result.add(Column.editor()
-        .name(INTERNAL_ID)
-        .position(result.size() + 1)
-        .type("INT64")
-        .autoIncremented(false)
-        .generated(false)
-        .optional(false)
-        .jdbcType(-5)
-        .nativeType(-1)
-        .length(19)
-        .scale(0)
-        .create());
-
-    return result;
-  }
-
   public TableSchema create(TopicNamingStrategy topicNamingStrategy, Table table,
       ColumnNameFilter filter, ColumnMappers mappers, KeyMapper keysMapper) {
-    // if (!table.primaryKeyColumnNames().isEmpty() && table.
     TableSchema schema = super.create(topicNamingStrategy, table, filter, mappers, keysMapper);
+    Schema keySchema = InternalIdUtils.getKeySchema(table, schema);
 
     if (!populateInternalId) {
       return new TableSchema(schema.id(),
-          schema.keySchema(),
+          keySchema,
           (row) -> schema.keyFromColumnData(row),
           schema.getEnvelopeSchema(),
           schema.valueSchema(),
           (row) -> schema.valueFromColumnData(row));
     } else {
-      Schema valSchema = addInternalId(schema.valueSchema());
-      List<Column> valColumns = addInternalId(table.columns());
+      Schema valSchema = InternalIdUtils.addInternalId(schema.valueSchema());
+      List<Column> valColumns = InternalIdUtils.addInternalId(table.columns());
       Envelope envelopeWithoutInternalId = schema.getEnvelopeSchema();
       Envelope envelope = Envelope.defineSchema()
           .withName(envelopeWithoutInternalId.schema().name())
@@ -91,7 +63,7 @@ public class SingleStoreTableSchemaBuilder extends TableSchemaBuilder {
           .build();
 
       return new TableSchema(schema.id(),
-          schema.keySchema(),
+          keySchema,
           (row) -> schema.keyFromColumnData(row),
           envelope,
           valSchema,

--- a/src/main/java/com/singlestore/debezium/SingleStoreTableSchemaBuilder.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreTableSchemaBuilder.java
@@ -70,11 +70,12 @@ public class SingleStoreTableSchemaBuilder extends TableSchemaBuilder {
 
   public TableSchema create(TopicNamingStrategy topicNamingStrategy, Table table,
       ColumnNameFilter filter, ColumnMappers mappers, KeyMapper keysMapper) {
+    // if (!table.primaryKeyColumnNames().isEmpty() && table.
     TableSchema schema = super.create(topicNamingStrategy, table, filter, mappers, keysMapper);
 
     if (!populateInternalId) {
       return new TableSchema(schema.id(),
-          SchemaBuilder.struct().field(INTERNAL_ID, Schema.INT64_SCHEMA).build(),
+          schema.keySchema(),
           (row) -> schema.keyFromColumnData(row),
           schema.getEnvelopeSchema(),
           schema.valueSchema(),
@@ -90,7 +91,7 @@ public class SingleStoreTableSchemaBuilder extends TableSchemaBuilder {
           .build();
 
       return new TableSchema(schema.id(),
-          SchemaBuilder.struct().field(INTERNAL_ID, Schema.INT64_SCHEMA).build(),
+          schema.keySchema(),
           (row) -> schema.keyFromColumnData(row),
           envelope,
           valSchema,

--- a/src/main/java/com/singlestore/debezium/util/InternalIdUtils.java
+++ b/src/main/java/com/singlestore/debezium/util/InternalIdUtils.java
@@ -1,0 +1,73 @@
+package com.singlestore.debezium.util;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableSchema;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+public class InternalIdUtils {
+
+  public static final String INTERNAL_ID = "internalId";
+
+  public static Schema getKeySchema(Table table, TableSchema schema) {
+    if (useInternalIdAsKey(table)) {
+      return SchemaBuilder.struct().field(INTERNAL_ID, Schema.INT64_SCHEMA).build();
+    } else {
+      return schema.keySchema();
+    }
+  }
+
+  private static boolean useInternalIdAsKey(Table table) {
+    return table.primaryKeyColumnNames().isEmpty() ||
+        !table.attributeWithName("IS_ROWSTORE").asBoolean();
+  }
+
+  public static Struct generateKey(Table table, TableSchema tableSchema, Object[] values,
+      Long internalId) {
+    if (useInternalIdAsKey(table)) {
+      return keyFromInternalId(internalId);
+    } else {
+      return tableSchema.keyFromColumnData(values);
+    }
+  }
+
+  private static Struct keyFromInternalId(Long internalId) {
+    Struct result = new Struct(
+        SchemaBuilder.struct().field(INTERNAL_ID, Schema.INT64_SCHEMA).build());
+    result.put(INTERNAL_ID, internalId);
+    return result;
+  }
+
+  public static Schema addInternalId(Schema s) {
+    SchemaBuilder res = SchemaBuilder.struct();
+    for (Field f : s.fields()) {
+      res.field(f.name(), f.schema());
+    }
+    res.field(INTERNAL_ID, Schema.INT64_SCHEMA);
+
+    return res.optional().build();
+  }
+
+  public static List<Column> addInternalId(List<Column> columns) {
+    List<Column> result = new ArrayList<>(columns);
+    result.add(Column.editor()
+        .name(INTERNAL_ID)
+        .position(result.size() + 1)
+        .type("INT64")
+        .autoIncremented(false)
+        .generated(false)
+        .optional(false)
+        .jdbcType(-5)
+        .nativeType(-1)
+        .length(19)
+        .scale(0)
+        .create());
+
+    return result;
+  }
+}

--- a/src/test/java/com/singlestore/debezium/IntegrationTestBase.java
+++ b/src/test/java/com/singlestore/debezium/IntegrationTestBase.java
@@ -35,7 +35,7 @@ abstract class IntegrationTestBase extends AbstractConnectorTest {
   static final String TEST_SERVER = System.getProperty("singlestore.hostname", "localhost");
   private static final String TEST_SERVER_VERSION = System.getProperty("singlestore.version", "");
   private static final String TEST_USER = System.getProperty("singlestore.user", "root");
-  private static final String TEST_PASSWORD = System.getProperty("singlestore.password", "root");
+  private static final String TEST_PASSWORD = "password";
   static final String TEST_DATABASE = "db";
   static final String TEST_TOPIC_PREFIX = "singlestore_topic";
   private static final String SINGLESTORE_LICENSE = System.getenv("SINGLESTORE_LICENSE");


### PR DESCRIPTION
In rowstore tables, internalId is not populated when there is a PK.
Thus changed to use PK as record key when rowstore table has it.
Later same changes should be done for columnstore tables.