### PR TITLE
Resume snapshot after the failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ name: Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "resumeSnapshot" ]
   pull_request:
     branches: [ "main" ]
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ in specific columns.
 ### Installation
 
 * Download
-  the [SingleStore connector for Debezium plugin archive](https://github.com/singlestore-labs/singlestore-debezium-connector/releases/download/v0.1.6-beta/singlestore-debezium-connector-0.1.6-beta-plugin.tar.gz).
+  the [SingleStore connector for Debezium plugin archive](https://github.com/singlestore-labs/singlestore-debezium-connector/releases/download/v0.1.7-beta/singlestore-debezium-connector-0.1.7-beta-plugin.tar.gz).
 * Extract the archive to a directory.
 * Add the directory from the previous step to Kafka Connect’s plugin path.
   Set the `plugin.path` property in the `connect-distributed.properties` file.
@@ -232,7 +232,7 @@ operation that inserts data in the `t` table:
          "a":33
       },
       "source":{
-         "version":"0.1.6-beta",
+         "version":"0.1.7-beta",
          "connector":"singlestore",
          "name":"singlestore",
          "ts_ms":1706197043473,
@@ -267,7 +267,7 @@ as the preceding create event.
          "a":22
       },
       "source":{
-         "version":"0.1.6-beta",
+         "version":"0.1.7-beta",
          "connector":"singlestore",
          "name":"singlestore",
          "ts_ms":1706197446500,
@@ -309,7 +309,7 @@ update event examples.
       "before":null,
       "after":null,
       "source":{
-         "version":"0.1.6-beta",
+         "version":"0.1.7-beta",
          "connector":"singlestore",
          "name":"singlestore",
          "ts_ms":1706197665407,

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ in specific columns.
 ### Installation
 
 * Download
-  the [SingleStore connector for Debezium plugin archive](https://github.com/singlestore-labs/singlestore-debezium-connector/releases/download/v0.1.7-beta/singlestore-debezium-connector-0.1.7-beta-plugin.tar.gz).
+  the [SingleStore connector for Debezium plugin archive](https://github.com/singlestore-labs/singlestore-debezium-connector/releases/download/v0.1.7/singlestore-debezium-connector-0.1.7-plugin.tar.gz).
 * Extract the archive to a directory.
 * Add the directory from the previous step to Kafka Connect’s plugin path.
   Set the `plugin.path` property in the `connect-distributed.properties` file.
@@ -232,7 +232,7 @@ operation that inserts data in the `t` table:
          "a":33
       },
       "source":{
-         "version":"0.1.7-beta",
+         "version":"0.1.7",
          "connector":"singlestore",
          "name":"singlestore",
          "ts_ms":1706197043473,
@@ -267,7 +267,7 @@ as the preceding create event.
          "a":22
       },
       "source":{
-         "version":"0.1.7-beta",
+         "version":"0.1.7",
          "connector":"singlestore",
          "name":"singlestore",
          "ts_ms":1706197446500,
@@ -309,7 +309,7 @@ update event examples.
       "before":null,
       "after":null,
       "source":{
-         "version":"0.1.7-beta",
+         "version":"0.1.7",
          "connector":"singlestore",
          "name":"singlestore",
          "ts_ms":1706197665407,

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.singlestore</groupId>
   <artifactId>singlestore-debezium-connector</artifactId>
-  <version>0.1.6-beta</version>
+  <version>0.1.7-beta</version>
   <name>singlestore-debezium-connector</name>
   <description>SingleStore Debezium Connector</description>
   <url>https://github.com/singlestore-labs/singlestore-debezium-connector</url>
@@ -33,7 +33,7 @@
     <developerConnection>
       scm:git:git@github.com:singlestore-labs/singlestore-debezium-connector.git
     </developerConnection>
-    <tag>singlestore-debezium-connector-0.1.6-beta</tag>
+    <tag>singlestore-debezium-connector-0.1.7-beta</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.singlestore</groupId>
   <artifactId>singlestore-debezium-connector</artifactId>
-  <version>0.1.7-beta</version>
+  <version>0.1.7</version>
   <name>singlestore-debezium-connector</name>
   <description>SingleStore Debezium Connector</description>
   <url>https://github.com/singlestore-labs/singlestore-debezium-connector</url>
@@ -33,7 +33,7 @@
     <developerConnection>
       scm:git:git@github.com:singlestore-labs/singlestore-debezium-connector.git
     </developerConnection>
-    <tag>singlestore-debezium-connector-0.1.7-beta</tag>
+    <tag>singlestore-debezium-connector-0.1.7</tag>
   </scm>
 
   <licenses>

--- a/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
@@ -12,6 +12,7 @@ import io.debezium.relational.Tables;
 import io.debezium.relational.Tables.ColumnNameFilter;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.util.Strings;
+import javax.swing.text.html.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,13 +45,12 @@ public class SingleStoreConnection extends JdbcConnection {
     this.connectionConfig = connectionConfig;
   }
 
-  public static String generateObserveQuery(TableId table, List<String> offsets) {
-    return String.format("OBSERVE * FROM %s BEGIN AT (%s)",
-        table.toQuotedString('`'), offsets
+  public String generateObserveQuery(TableId table, List<String> offsets) {
+    return observeQuery(null, Set.of(table), Optional.empty(), Optional.empty(),
+        Optional.of(String.format("(%s)", offsets
             .stream()
             .map(o -> o == null ? "NULL" : "'" + o + "'")
-            .collect(Collectors.joining(","))
-    );
+            .collect(Collectors.joining(",")))), Optional.empty());
   }
 
   public boolean isRowstoreTable(TableId tableId) throws SQLException {

--- a/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
@@ -32,17 +32,25 @@ import static io.debezium.config.CommonConnectorConfig.DRIVER_CONFIG_PREFIX;
 public class SingleStoreConnection extends JdbcConnection {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(
-          SingleStoreConnection.class);
+      SingleStoreConnection.class);
   private static final String QUOTED_CHARACTER = "`";
   protected static final String URL_PATTERN = "jdbc:singlestore://${hostname}:${port}/?connectTimeout=${connectTimeout}";
   protected static final String URL_PATTERN_DATABASE = "jdbc:singlestore://${hostname}:${port}/${dbname}?connectTimeout=${connectTimeout}";
-
   private final SingleStoreConnectionConfiguration connectionConfig;
 
   public SingleStoreConnection(SingleStoreConnectionConfiguration connectionConfig) {
     super(connectionConfig.jdbcConfig, connectionConfig.factory,
         SingleStoreConnection::validateServerVersion, QUOTED_CHARACTER, QUOTED_CHARACTER);
     this.connectionConfig = connectionConfig;
+  }
+
+  public static String generateObserveQuery(TableId table, List<String> offsets) {
+    return String.format("OBSERVE * FROM %s BEGIN AT (%s)",
+        table.toQuotedString('`'), offsets
+            .stream()
+            .map(o -> o == null ? "NULL" : "'" + o + "'")
+            .collect(Collectors.joining(","))
+    );
   }
 
   public boolean isRowstoreTable(TableId tableId) throws SQLException {
@@ -59,6 +67,16 @@ public class SingleStoreConnection extends JdbcConnection {
         });
 
     return res.get();
+  }
+
+  private static void validateServerVersion(Statement statement) throws SQLException {
+    DatabaseMetaData metaData = statement.getConnection().getMetaData();
+    int majorVersion = metaData.getDatabaseMajorVersion();
+    int minorVersion = metaData.getDatabaseMinorVersion();
+    if (majorVersion < 8 || (majorVersion == 8 && minorVersion < 5)) {
+      throw new SQLException(
+          "CDC feature is not supported in a version of SingleStore lower than 8.5");
+    }
   }
 
   public void addIsRowstoreAttribute(Tables tables) throws SQLException {
@@ -80,16 +98,6 @@ public class SingleStoreConnection extends JdbcConnection {
     super.readSchema(tables, databaseCatalog, schemaNamePattern, tableFilter, columnFilter,
         removeTablesNotFoundInJdbc);
     addIsRowstoreAttribute(tables);
-  }
-
-  private static void validateServerVersion(Statement statement) throws SQLException {
-    DatabaseMetaData metaData = statement.getConnection().getMetaData();
-    int majorVersion = metaData.getDatabaseMajorVersion();
-    int minorVersion = metaData.getDatabaseMinorVersion();
-    if (majorVersion < 8 || (majorVersion == 8 && minorVersion < 5)) {
-      throw new SQLException(
-          "CDC feature is not supported in a version of SingleStore lower than 8.5");
-    }
   }
 
   /**
@@ -141,23 +149,24 @@ public class SingleStoreConnection extends JdbcConnection {
       Optional<OBSERVE_OUTPUT_FORMAT> format,
       Optional<String> outputConfig, Optional<String> offSetConfig, Optional<String> recordFilter,
       ResultSetConsumer resultSetConsumer) throws SQLException {
-    final String query = observeQuery(fieldFilter, tableFilter, format, outputConfig, offSetConfig, recordFilter);
+    final String query = observeQuery(fieldFilter, tableFilter, format, outputConfig, offSetConfig,
+        recordFilter);
     return query(query, resultSetConsumer);
   }
 
   private String observeQuery(Set<ColumnId> fieldFilter, Set<TableId> tableFilter,
-                              Optional<OBSERVE_OUTPUT_FORMAT> format,
-                              Optional<String> outputConfig, Optional<String> offSetConfig, Optional<String> recordFilter) {
+      Optional<OBSERVE_OUTPUT_FORMAT> format,
+      Optional<String> outputConfig, Optional<String> offSetConfig, Optional<String> recordFilter) {
     StringBuilder query = new StringBuilder("OBSERVE ");
     if (fieldFilter != null && !fieldFilter.isEmpty()) {
       query.append(fieldFilter.stream().map(this::quotedColumnIdString)
-              .collect(Collectors.joining(","))).append(" FROM ");
+          .collect(Collectors.joining(","))).append(" FROM ");
     } else {
       query.append("* FROM ");
     }
     if (tableFilter != null && !tableFilter.isEmpty()) {
       query.append(
-              tableFilter.stream().map(this::quotedTableIdString).collect(Collectors.joining(",")));
+          tableFilter.stream().map(this::quotedTableIdString).collect(Collectors.joining(",")));
     } else {
       query.append("*");
     }
@@ -174,16 +183,21 @@ public class SingleStoreConnection extends JdbcConnection {
    * @param offset to validate
    * @return true if streaming is possible for given offset, false otherwise
    */
-  public boolean validateOffset(Set<TableId> tableFilter, SingleStorePartition partition, SingleStoreOffsetContext offset) {
-    List<String> offsets = offset.offsets().stream().filter(Objects::nonNull).map(o -> "'" + o + "'").collect(Collectors.toList());
+  public boolean validateOffset(Set<TableId> tableFilter, SingleStorePartition partition,
+      SingleStoreOffsetContext offset) {
+    List<String> offsets = offset.offsets().stream().filter(Objects::nonNull)
+        .map(o -> "'" + o + "'").collect(Collectors.toList());
     Optional<String> offsetParam = Optional.of("(" + String.join(",", offsets) + ")");
-    final String query = observeQuery(null, tableFilter, Optional.empty(), Optional.empty(), offsetParam, Optional.empty());
+    final String query = observeQuery(null, tableFilter, Optional.empty(), Optional.empty(),
+        offsetParam, Optional.empty());
     //sometimes same observe query is failed after second time execution with the same offset
-    try (Statement statement = connection().createStatement(); AutoClosableResultSetWrapper rsWrapper = AutoClosableResultSetWrapper.from(statement.executeQuery(query))) {
+    try (Statement statement = connection().createStatement(); AutoClosableResultSetWrapper rsWrapper = AutoClosableResultSetWrapper.from(
+        statement.executeQuery(query))) {
       rsWrapper.getResultSet().next();
     } catch (SQLException e) {
-      if (e.getMessage().contains("The requested Offset is too stale. Please re-start the OBSERVE query from the latest snapshot.")
-              && e.getErrorCode() == 2851 && e.getSQLState().equals("HY000")) {
+      if (e.getMessage().contains(
+          "The requested Offset is too stale. Please re-start the OBSERVE query from the latest snapshot.")
+          && e.getErrorCode() == 2851 && e.getSQLState().equals("HY000")) {
         LOGGER.warn("Failed to validate offset {}", offsetParam.get());
         return false;
       } else {

--- a/src/main/java/com/singlestore/debezium/SingleStoreConnector.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreConnector.java
@@ -6,12 +6,15 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.common.RelationalBaseSourceConnector;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
+import com.singlestore.debezium.SingleStoreConnectorConfig.SnapshotMode;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
@@ -112,5 +115,24 @@ public class SingleStoreConnector extends RelationalBaseSourceConnector {
     } catch (SQLException e) {
       throw new DebeziumException(e);
     }
+  }
+
+  @Override
+  public Config validate(Map<String, String> connectorConfigs) {
+    Config res = super.validate(connectorConfigs);
+
+    Configuration config = Configuration.from(connectorConfigs);
+    SingleStoreConnectorConfig connectorConfig = new SingleStoreConnectorConfig(config);
+    if (connectorConfig.getSnapshotMode() == SnapshotMode.SCHEMA_ONLY
+        && connectorConfig.offsets() == null) {
+      res.configValues().forEach(value -> {
+        if (value.name().equals(SingleStoreConnectorConfig.OFFSETS.name())) {
+          value.addErrorMessage(
+              "'offsets' parameter is required when 'snapshot.mode' is 'schema_only'");
+        }
+      });
+    }
+
+    return res;
   }
 }

--- a/src/main/java/com/singlestore/debezium/SingleStoreErrorHandler.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreErrorHandler.java
@@ -22,4 +22,19 @@ public class SingleStoreErrorHandler extends ErrorHandler {
         WrongOffsetException.class);
   }
 
+  protected boolean isRetriable(Throwable throwable) {
+    if (throwable instanceof SQLException) {
+      SQLException e = (SQLException) throwable;
+      if (e.getMessage().contains(
+          "The requested Offset is too stale. Please re-start the OBSERVE query from the latest snapshot.")
+          &&
+          e.getErrorCode() == 2851 &&
+          e.getSQLState().equals("HY000")
+      ) {
+        return false;
+      }
+    }
+    
+    return super.isRetriable(throwable);
+  }
 }

--- a/src/main/java/com/singlestore/debezium/SingleStoreErrorHandler.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreErrorHandler.java
@@ -23,18 +23,10 @@ public class SingleStoreErrorHandler extends ErrorHandler {
   }
 
   protected boolean isRetriable(Throwable throwable) {
-    if (throwable instanceof SQLException) {
-      SQLException e = (SQLException) throwable;
-      if (e.getMessage().contains(
-          "The requested Offset is too stale. Please re-start the OBSERVE query from the latest snapshot.")
-          &&
-          e.getErrorCode() == 2851 &&
-          e.getSQLState().equals("HY000")
-      ) {
-        return false;
-      }
+    if (throwable instanceof StaleOffsetException) {
+      return false;
     }
-    
+
     return super.isRetriable(throwable);
   }
 }

--- a/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
@@ -1,6 +1,5 @@
 package com.singlestore.debezium;
 
-import com.singlestore.debezium.exception.WrongOffsetException;
 import com.singlestore.debezium.util.ObserveResultSetUtils;
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.jdbc.JdbcConnection;
@@ -20,28 +19,22 @@ import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.util.Clock;
 import io.debezium.util.Strings;
 import io.debezium.util.Threads;
-
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalLong;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,13 +45,10 @@ public class SingleStoreSnapshotChangeEventSource extends
   private static final Logger LOGGER = LoggerFactory
       .getLogger(SingleStoreSnapshotChangeEventSource.class);
 
-  private final Set<String> OFFSET_SET = new HashSet<>();
-  private volatile boolean offsetIsWrong;
   private final SingleStoreConnectorConfig connectorConfig;
   private final SingleStoreConnection jdbcConnection;
   private final SingleStoreDatabaseSchema schema;
   private final SnapshotProgressListener<SingleStorePartition> snapshotProgressListener;
-  private final MainConnectionProvidingConnectionFactory<? extends JdbcConnection> jdbcConnectionFactory;
 
   public SingleStoreSnapshotChangeEventSource(SingleStoreConnectorConfig connectorConfig,
       MainConnectionProvidingConnectionFactory<SingleStoreConnection> jdbcConnectionFactory,
@@ -72,7 +62,6 @@ public class SingleStoreSnapshotChangeEventSource extends
     this.jdbcConnection = jdbcConnectionFactory.mainConnection();
     this.schema = schema;
     this.snapshotProgressListener = snapshotProgressListener;
-    this.jdbcConnectionFactory = jdbcConnectionFactory;
   }
 
   @Override
@@ -85,7 +74,6 @@ public class SingleStoreSnapshotChangeEventSource extends
 
     Connection connection = null;
     Exception exceptionWhileSnapshot = null;
-    Queue<JdbcConnection> connectionPool = null;
     try {
       Set<Pattern> dataCollectionsToBeSnapshotted = getDataCollectionPattern(
           snapshottingTask.getDataCollections());
@@ -116,9 +104,8 @@ public class SingleStoreSnapshotChangeEventSource extends
 
       if (snapshottingTask.snapshotData()) {
         LOGGER.info("Snapshot step 4.a - Creating connection pool");
-        connectionPool = createConnectionPool(ctx);
         LOGGER.info("Snapshot step 5 - Snapshotting data");
-        createDataEvents(context, ctx, connectionPool);
+        createDataEvents(context, ctx, jdbcConnection);
       } else {
         LOGGER.info("Snapshot step 5 - Skipping snapshotting of data");
         releaseDataSnapshotLocks(ctx);
@@ -155,126 +142,39 @@ public class SingleStoreSnapshotChangeEventSource extends
   private void createDataEvents(ChangeEventSource.ChangeEventSourceContext sourceContext,
       RelationalSnapshotChangeEventSource.RelationalSnapshotContext<SingleStorePartition,
           SingleStoreOffsetContext> snapshotContext,
-      Queue<JdbcConnection> connectionPool) throws Exception {
+      JdbcConnection conn) throws Exception {
     tryStartingSnapshot(snapshotContext);
 
     EventDispatcher.SnapshotReceiver<SingleStorePartition> snapshotReceiver = dispatcher
         .getSnapshotChangeEventReceiver();
-    int snapshotMaxThreads = connectionPool.size();
-    LOGGER.info("Creating snapshot with {} worker thread(s)", snapshotMaxThreads);
-    ExecutorService executorService = Executors.newFixedThreadPool(snapshotMaxThreads);
-    CompletionService<SingleStoreOffsetContext> completionService = new ExecutorCompletionService<>(
-        executorService);
-    Queue<SingleStoreOffsetContext> offsets = new ConcurrentLinkedQueue<>();
-    offsets.add(snapshotContext.offset);
-    for (int i = 1; i < snapshotMaxThreads; i++) {
-      offsets.add(copyOffset(snapshotContext));
-    }
 
-    Map<TableId, String> queryTables = new HashMap<>();
-    Map<TableId, OptionalLong> rowCountTables = new LinkedHashMap<>();
-    for (TableId tableId : snapshotContext.capturedTables) {
-      final String selectStatement = determineSnapshotSelect(snapshotContext, tableId);
-      LOGGER.info("For table '{}' using select statement: '{}'", tableId, selectStatement);
-      queryTables.put(tableId, selectStatement);
-      final OptionalLong rowCount = rowCountForTable(tableId);
-      rowCountTables.put(tableId, rowCount);
-    }
+    // We must have only one table
+    assert (snapshotContext.capturedTables.size() == 1);
+    TableId table = snapshotContext.capturedTables.iterator().next();
+    final String selectStatement = determineSnapshotSelect(snapshotContext, table);
 
-    int tableCount = rowCountTables.size();
-    List<Callable<SingleStoreOffsetContext>> dataEventTasks = new ArrayList<>(tableCount);
-    CyclicBarrier barrier = new CyclicBarrier(tableCount);
-    int tableOrder = 1;
-    for (TableId tableId : rowCountTables.keySet()) {
-      boolean firstTable = tableOrder == 1 && snapshotMaxThreads == 1;
-      boolean lastTable = tableOrder == tableCount && snapshotMaxThreads == 1;
-      String selectStatement = queryTables.get(tableId);
-      OptionalLong rowCount = rowCountTables.get(tableId);
-      Callable<SingleStoreOffsetContext> callable = createDataEventsForTableCallable(sourceContext,
-          snapshotContext, snapshotReceiver,
-          snapshotContext.tables.forTable(tableId), firstTable, lastTable, tableOrder++, tableCount,
-          selectStatement,
-          rowCount, offsets, connectionPool, barrier);
-      dataEventTasks.add(callable);
-    }
-    List<SingleStoreOffsetContext> commitSnapshotOffsetList = new ArrayList<>(tableCount);
-    try {
-      for (Callable<SingleStoreOffsetContext> callable : dataEventTasks) {
-        completionService.submit(callable);
-      }
-      for (int i = 0; i < dataEventTasks.size(); i++) {
-        commitSnapshotOffsetList.add(completionService.take().get());
-      }
-    } catch (ExecutionException e) {
-      if (e.getCause() != null && e.getCause() instanceof WrongOffsetException) {
-        throw new WrongOffsetException(e.getCause());
-      } else {
-        throw e;
-      }
-    } finally {
-      offsetIsWrong = false;
-      OFFSET_SET.clear();
-      barrier.reset();
-      executorService.shutdownNow();
-    }
-    commitSnapshotOffsetList.forEach(o -> {
-      List<String> offsetList = o.offsets();
-      for (int i = 0; i < offsetList.size(); i++) {
-        if (offsetList.get(i) != null) {
-          snapshotContext.offset.update(i, o.txId(), offsetList.get(i));
-        }
-      }
-    });
+    doCreateDataEventsForTable(sourceContext, snapshotContext, snapshotContext.offset,
+        snapshotReceiver, snapshotContext.tables.forTable(table), selectStatement,
+        conn);
 
-    for (SingleStoreOffsetContext offset : offsets) {
-      offset.preSnapshotCompletion();
-    }
+    snapshotContext.offset.preSnapshotCompletion();
     snapshotReceiver.completeSnapshot();
-    for (SingleStoreOffsetContext offset : offsets) {
-      offset.postSnapshotCompletion();
-    }
+    snapshotContext.offset.postSnapshotCompletion();
   }
 
-  private Callable<SingleStoreOffsetContext> createDataEventsForTableCallable(
-      ChangeEventSource.ChangeEventSourceContext sourceContext,
-      RelationalSnapshotChangeEventSource.RelationalSnapshotContext<SingleStorePartition, SingleStoreOffsetContext> snapshotContext,
-      EventDispatcher.SnapshotReceiver<SingleStorePartition> snapshotReceiver, Table table,
-      boolean firstTable, boolean lastTable, int tableOrder,
-      int tableCount, String selectStatement, OptionalLong rowCount,
-      Queue<SingleStoreOffsetContext> offsets, Queue<JdbcConnection> connectionPool,
-      CyclicBarrier barrier) {
-    return () -> {
-      JdbcConnection connection = connectionPool.poll();
-      SingleStoreOffsetContext offset = offsets.poll();
-      try {
-        return doCreateDataEventsForTable(sourceContext, snapshotContext, offset, snapshotReceiver,
-            table,
-            firstTable, lastTable, tableOrder, tableCount, selectStatement, rowCount, connection,
-            barrier);
-      } finally {
-        offsets.add(offset);
-        connectionPool.add(connection);
-      }
-    };
-  }
-
-  private SingleStoreOffsetContext doCreateDataEventsForTable(
+  private void doCreateDataEventsForTable(
       ChangeEventSource.ChangeEventSourceContext sourceContext,
       RelationalSnapshotChangeEventSource.RelationalSnapshotContext<SingleStorePartition, SingleStoreOffsetContext> snapshotContext,
       SingleStoreOffsetContext offset,
       EventDispatcher.SnapshotReceiver<SingleStorePartition> snapshotReceiver, Table table,
-      boolean firstTable, boolean lastTable, int tableOrder, int tableCount,
-      String selectStatement, OptionalLong rowCount, JdbcConnection jdbcConnection,
-      CyclicBarrier barrier)
+      String selectStatement, JdbcConnection jdbcConnection)
       throws InterruptedException {
     SingleStorePartition partition = snapshotContext.partition;
     if (!sourceContext.isRunning()) {
       throw new InterruptedException("Interrupted while snapshotting table " + table.id());
     }
-    SingleStoreOffsetContext commitOffset = copyOffset(snapshotContext);
     long exportStart = clock.currentTimeInMillis();
-    LOGGER.info("Exporting data from table '{}' ({} of {} tables)", table.id(), tableOrder,
-        tableCount);
+    LOGGER.info("Exporting data from table '{}'", table.id());
     Instant sourceTableSnapshotTimestamp = getSnapshotSourceTimestamp(jdbcConnection, offset,
         table.id());
     try (Statement statement = jdbcConnection.connection().createStatement();
@@ -287,107 +187,51 @@ public class SingleStoreSnapshotChangeEventSource extends
                   connectorConfig.populateInternalId());
       long rows = 0;
       Threads.Timer logTimer = getTableScanLogTimer();
-      boolean hasNext = validateBeginSnapshotResultSet(rs);
-      barrier.await();
+
       int numPartitions = snapshotContext.offset.offsets().size();
-      if (hasNext) {
-        while (hasNext && numPartitions > 0) {
-          if (offsetIsWrong) {
-            throw new InterruptedException("Interrupted while snapshotting table " + table.id()
-                + ", because of wrong StartSnapshot offset");
+      List<Boolean> snapshotCommitted = new ArrayList<>(Collections.nCopies(numPartitions, false));
+      while (numPartitions > 0 && rs.next()) {
+        LOGGER.trace(
+            "Snapshot record, type: {}, internalId: {}, partitionId: {}, offset: {} values: {}",
+            ObserveResultSetUtils.snapshotType(rs),
+            ObserveResultSetUtils.internalId(rs),
+            ObserveResultSetUtils.partitionId(rs),
+            ObserveResultSetUtils.offset(rs),
+            ObserveResultSetUtils.rowToArray(rs, columnPostitions));
+
+        int partitionId = ObserveResultSetUtils.partitionId(rs);
+        if (ObserveResultSetUtils.isCommitSnapshot(rs)) {
+          numPartitions--;
+          snapshotCommitted.set(partitionId, true);
+        } else if (!ObserveResultSetUtils.isBeginSnapshot(rs)
+            && !snapshotCommitted.get(partitionId)) {
+          rows++;
+          final Object[] row = ObserveResultSetUtils.rowToArray(rs, columnPostitions);
+          final Long internalId = ObserveResultSetUtils.internalId(rs);
+          if (logTimer.expired()) {
+            long stop = clock.currentTimeInMillis();
+            LOGGER.info("\t Exported {} records for table '{}' after {}", rows, table.id(),
+                Strings.duration(stop - exportStart));
+            snapshotProgressListener.rowsScanned(partition, table.id(), rows);
+            logTimer = getTableScanLogTimer();
           }
-          LOGGER.trace(
-              "Snapshot record, type: {}, internalId: {}, partitionId: {}, offset: {} values: {}",
-              ObserveResultSetUtils.snapshotType(rs),
-              ObserveResultSetUtils.internalId(rs),
-              ObserveResultSetUtils.partitionId(rs),
-              ObserveResultSetUtils.offset(rs),
-              ObserveResultSetUtils.rowToArray(rs, columnPostitions));
-          if (ObserveResultSetUtils.isBeginSnapshot(rs)) {
-            hasNext = rs.next();
-          } else if (ObserveResultSetUtils.isCommitSnapshot(rs)) {
-            numPartitions--;
-            updateSnapshotOffset(commitOffset, rs);
-            if (numPartitions == 0) {
-              break;
-            }
-            hasNext = rs.next();
-          } else {
-            rows++;
-            final Object[] row = ObserveResultSetUtils.rowToArray(rs, columnPostitions);
-            final Long internalId = ObserveResultSetUtils.internalId(rs);
-            if (logTimer.expired()) {
-              long stop = clock.currentTimeInMillis();
-              if (rowCount.isPresent()) {
-                LOGGER.info("\t Exported {} of {} records for table '{}' after {}", rows,
-                    rowCount.getAsLong(),
-                    table.id(), Strings.duration(stop - exportStart));
-              } else {
-                LOGGER.info("\t Exported {} records for table '{}' after {}", rows, table.id(),
-                    Strings.duration(stop - exportStart));
-              }
-              snapshotProgressListener.rowsScanned(partition, table.id(), rows);
-              logTimer = getTableScanLogTimer();
-            }
-            updateSnapshotOffset(offset, rs);
-            hasNext = rs.next();
-            setSnapshotMarker(offset, firstTable, lastTable, rows == 1,
-                ObserveResultSetUtils.isCommitSnapshot(rs) && numPartitions == 1);
-            dispatcher.dispatchSnapshotEvent(partition, table.id(),
-                getChangeRecordEmitter(partition, offset, table.id(), table, row,
-                    internalId,
-                    sourceTableSnapshotTimestamp), snapshotReceiver);
+          updateSnapshotOffset(offset, rs);
+          if (rows == 1) {
+            offset.markSnapshotRecord(SnapshotRecord.FIRST);
           }
+          dispatcher.dispatchSnapshotEvent(partition, table.id(),
+              getChangeRecordEmitter(partition, offset, table.id(), table, row,
+                  internalId,
+                  sourceTableSnapshotTimestamp), snapshotReceiver);
         }
-      } else {
-        setSnapshotMarker(offset, firstTable, lastTable, false, true);
       }
+
       LOGGER.info(
-          "\t Finished exporting {} records for table '{}' ({} of {} tables); total duration '{}'",
-          rows, table.id(), tableOrder, tableCount,
-          Strings.duration(clock.currentTimeInMillis() - exportStart));
+          "\t Finished exporting {} records for table '{}'; total duration '{}'",
+          rows, table.id(), Strings.duration(clock.currentTimeInMillis() - exportStart));
       snapshotProgressListener.dataCollectionSnapshotCompleted(partition, table.id(), rows);
-    } catch (SQLException | BrokenBarrierException e) {
+    } catch (SQLException e) {
       throw new ConnectException("Snapshotting of table " + table.id() + " failed", e);
-    }
-    return commitOffset;
-  }
-
-  private boolean validateBeginSnapshotResultSet(ResultSet rs) throws SQLException {
-    if (rs.next()) {
-      if (!ObserveResultSetUtils.isBeginSnapshot(rs)) {
-        LOGGER.warn(
-            "Observe query first row response must be of 'BeginSnapshot' type, skip snapshotting");
-        return false;
-      }
-      String offset = ObserveResultSetUtils.offset(rs);
-      validateBeginOffset(offset);
-      return rs.next();
-    }
-    return false;
-  }
-
-  private synchronized void validateBeginOffset(String offset) {
-    OFFSET_SET.add(offset);
-    if (OFFSET_SET.size() > 1) {
-      offsetIsWrong = true;
-      throw new WrongOffsetException("StartSnapshot offset is wrong.");
-    }
-  }
-
-  private void setSnapshotMarker(SingleStoreOffsetContext offset, boolean firstTable,
-      boolean lastTable, boolean firstRecordInTable,
-      boolean lastRecordInTable) {
-    if (lastRecordInTable && lastTable) {
-      offset.markSnapshotRecord(SnapshotRecord.LAST);
-    } else if (firstRecordInTable && firstTable) {
-      offset.markSnapshotRecord(SnapshotRecord.FIRST);
-    } else if (lastRecordInTable) {
-      offset.markSnapshotRecord(SnapshotRecord.LAST_IN_DATA_COLLECTION);
-    } else if (firstRecordInTable) {
-      offset.markSnapshotRecord(SnapshotRecord.FIRST_IN_DATA_COLLECTION);
-    } else {
-      offset.markSnapshotRecord(SnapshotRecord.TRUE);
     }
   }
 
@@ -480,29 +324,6 @@ public class SingleStoreSnapshotChangeEventSource extends
         .filter(tid -> pattern.asMatchPredicate()
             .test(connectorConfig.getTableIdMapper().toString(tid)))
         .sorted();
-  }
-
-  private Queue<JdbcConnection> createConnectionPool(
-      final RelationalSnapshotContext<SingleStorePartition, SingleStoreOffsetContext> ctx)
-      throws SQLException {
-    Queue<JdbcConnection> connectionPool = new ConcurrentLinkedQueue<>();
-    connectionPool.add(jdbcConnection);
-
-    int snapshotMaxThreads = ctx.capturedTables.size();
-    if (snapshotMaxThreads > 1) {
-      Optional<String> firstQuery = getSnapshotConnectionFirstSelect(ctx,
-          ctx.capturedTables.iterator().next());
-      for (int i = 1; i < snapshotMaxThreads; i++) {
-        JdbcConnection conn = jdbcConnectionFactory.newConnection().setAutoCommit(false);
-        connectionPoolConnectionCreated(ctx, conn);
-        connectionPool.add(conn);
-        if (firstQuery.isPresent()) {
-          conn.execute(firstQuery.get());
-        }
-      }
-    }
-    LOGGER.info("Created connection pool with {} threads", snapshotMaxThreads);
-    return connectionPool;
   }
 
   private void rollbackTransaction(Connection connection) {
@@ -628,7 +449,8 @@ public class SingleStoreSnapshotChangeEventSource extends
       TableId tableId, List<String> columns) {
     String snapshotSelectColumns = columns.stream()
         .collect(Collectors.joining(", "));//todo use in observe query
-    return Optional.of(String.format("OBSERVE * FROM %s.%s", tableId.catalog(), tableId.table()));
+    return Optional.of(
+        SingleStoreConnection.generateObserveQuery(tableId, snapshotContext.offset.offsets()));
   }
 
   @Override

--- a/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
@@ -450,7 +450,7 @@ public class SingleStoreSnapshotChangeEventSource extends
     String snapshotSelectColumns = columns.stream()
         .collect(Collectors.joining(", "));//todo use in observe query
     return Optional.of(
-        SingleStoreConnection.generateObserveQuery(tableId, snapshotContext.offset.offsets()));
+        jdbcConnection.generateObserveQuery(tableId, snapshotContext.offset.offsets()));
   }
 
   @Override

--- a/src/main/java/com/singlestore/debezium/SingleStoreStreamingChangeEventSource.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreStreamingChangeEventSource.java
@@ -76,7 +76,7 @@ public class SingleStoreStreamingChangeEventSource implements
       t.start();
 
       dispatcher.dispatchConnectorEvent(partition, ObserveStreamingStartedEvent.INSTANCE);
-      String query = SingleStoreConnection.generateObserveQuery(table, offsetContext.offsets());
+      String query = connection.generateObserveQuery(table, offsetContext.offsets());
       try (
           Statement stmt = conn.createStatement();
           ResultSet rs = stmt.executeQuery(query)

--- a/src/main/java/com/singlestore/debezium/StaleOffsetException.java
+++ b/src/main/java/com/singlestore/debezium/StaleOffsetException.java
@@ -1,0 +1,10 @@
+package com.singlestore.debezium;
+
+import java.sql.SQLException;
+
+public class StaleOffsetException extends SQLException {
+
+  public StaleOffsetException(Throwable t) {
+    super(t);
+  }
+}

--- a/src/test/java/com/singlestore/debezium/StreamingIT.java
+++ b/src/test/java/com/singlestore/debezium/StreamingIT.java
@@ -171,7 +171,7 @@ public class StreamingIT extends IntegrationTestBase {
         SourceRecord record = records.get(0);
 
         Struct source = (Struct) ((Struct) record.value()).get("source");
-        assertEquals(source.get("version"), "0.1.6-beta");
+        assertEquals(source.get("version"), "0.1.7-beta");
         assertEquals(source.get("connector"), "singlestore");
         assertEquals(source.get("name"), "singlestore_topic");
         assertNotNull(source.get("ts_ms"));

--- a/src/test/java/com/singlestore/debezium/StreamingIT.java
+++ b/src/test/java/com/singlestore/debezium/StreamingIT.java
@@ -171,7 +171,7 @@ public class StreamingIT extends IntegrationTestBase {
         SourceRecord record = records.get(0);
 
         Struct source = (Struct) ((Struct) record.value()).get("source");
-        assertEquals(source.get("version"), "0.1.7-beta");
+        assertEquals(source.get("version"), "0.1.7");
         assertEquals(source.get("connector"), "singlestore");
         assertEquals(source.get("name"), "singlestore_topic");
         assertNotNull(source.get("ts_ms"));

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,9 +16,9 @@
   <logger name="io.debezium" level="trace" additivity="false">
     <appender-ref ref="CONSOLE"/>
   </logger>
-
-  <logger name="io.debezium.jdbc.JdbcConnection" level="trace" additivity="false">
-    <appender-ref ref="CONSOLE"/>
-  </logger>
-
+  <!--
+    <logger name="io.debezium.jdbc.JdbcConnection" level="trace" additivity="false">
+      <appender-ref ref="CONSOLE"/>
+    </logger>
+  -->
 </configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -13,6 +13,10 @@
     <appender-ref ref="CONSOLE"/>
   </logger>
 
+  <logger name="io.debezium" level="trace" additivity="false">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+
   <logger name="io.debezium.jdbc.JdbcConnection" level="trace" additivity="false">
     <appender-ref ref="CONSOLE"/>
   </logger>


### PR DESCRIPTION
Fixed a bug with queue creation which caused the connector not to restart after the failure.
Simplified code by removing parallel read from several tables in snapshotting (currently connector supports only reading from a single table).
Changed connector to resume snapshot from the last saved point.
Manually tested that connector resumes.
