### PR TITLE
Changed key generation for columnstore tables with primary key

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,15 +173,15 @@ It represents a unique ID assigned to each row in the database.
       ]
    },
    "payload":{ (2)
-      "InternalId":1152921504606847003
+      "InternalId": "100000000000000600000007"
    }
 }
 ```
 
-| Item | Field name | Description                                                                                                                                                                                                       
-|------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| 1    | `schema`   | Specifies a Kafka Connect schema that describes the structure of the key's `payload`.                                                                                                                             
-| 2    | `payload`  | For rowstore tables that have a primary key, contains primary key fields. For all other tables, contains a single field `internalId` used to specify the ID of the row for which this change event was generated. 
+| Item | Field name | Description                                                                                                                                                                                              
+|------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| 1    | `schema`   | Specifies a Kafka Connect schema that describes the structure of the key's `payload`.                                                                                                                    
+| 2    | `payload`  | For tables that have a primary key, contains primary key fields. For all other tables, contains a single field `internalId` used to specify the ID of the row for which this change event was generated. 
 
 ### Change event values
 

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ describes the structure of the payload, while the payload contains the actual da
 
 ### Change event keys
 
-The change event key payload for rowstore tables that have a primary key consists of primary key
+The change event key payload for tables that have a primary key consists of primary key
 fields.
-The change event key payload for all other tables consists of a single field named `internalid`.
+The change event key payload for all other tables consists of a single field named `InternalId`.
 It represents a unique ID assigned to each row in the database.
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -1,231 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-
-  <groupId>com.singlestore</groupId>
   <artifactId>singlestore-debezium-connector</artifactId>
-  <version>0.1.7</version>
-  <name>singlestore-debezium-connector</name>
-  <description>SingleStore Debezium Connector</description>
-  <url>https://github.com/singlestore-labs/singlestore-debezium-connector</url>
-
-  <organization>
-    <name>SingleStore</name>
-    <url>https://www.singlestore.com/</url>
-  </organization>
-
-  <developers>
-    <developer>
-      <id>singlestore</id>
-      <name>SingleStore</name>
-      <email>team@singlestore.com</email>
-      <organization>SingleStore</organization>
-      <organizationUrl>https://www.singlestore.com/</organizationUrl>
-    </developer>
-  </developers>
-
-  <scm>
-    <url>git://git@github.com:singlestore-labs/singlestore-debezium-connector.git</url>
-    <connection>scm:git:git@github.com:singlestore-labs/singlestore-debezium-connector.git
-    </connection>
-    <developerConnection>
-      scm:git:git@github.com:singlestore-labs/singlestore-debezium-connector.git
-    </developerConnection>
-    <tag>singlestore-debezium-connector-0.1.7</tag>
-  </scm>
-
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-
-    <version.debezium>2.5.1.Final</version.debezium>
-    <version.kafka>3.6.1</version.kafka>
-    <version.singlestore.jdbc.driver>1.2.0</version.singlestore.jdbc.driver>
-    <version.jts.io>1.19.0</version.jts.io>
-
-    <version.kafka-connect-avro-converter>7.5.1</version.kafka-connect-avro-converter>
-    <version.connect-json>3.6.1</version.connect-json>
-    <version.org.slf4j>2.0.4</version.org.slf4j>
-    <version.logback-classic>1.4.14</version.logback-classic>
-    <version.testcontainers>1.19.3</version.testcontainers>
-    <version.awaitility>4.2.0</version.awaitility>
-    <version.mockito>3.0.0</version.mockito>
-    <version.junit>4.13.2</version.junit>
-    <version.assertj-core>3.11.1</version.assertj-core>
-
-    <version.assembly.plugin>3.6.0</version.assembly.plugin>
-    <version.failsafe.plugin>3.2.3</version.failsafe.plugin>
-
-    <!--
-      Specify the properties that will be used for setting up the integration tests' Docker container.
-      Note that the `dockerhost.ip` property is computed from the IP address of DOCKER_HOST, which will
-      work on all platforms. We'll set some of these as system properties during integration testing.
-    -->
-    <singlestore.image>ghcr.io/singlestore-labs/singlestoredb-dev:latest</singlestore.image>
-    <singlestore.version>dev:92a8a199-13fd-462d-a9ec-58ef94754473</singlestore.version>
-    <singlestore.license>${env.SINGLESTORE_LICENSE}</singlestore.license>
-    <singlestore.host>127.0.0.1</singlestore.host>
-    <singlestore.port>3306</singlestore.port>
-    <singlestore.user>root</singlestore.user>
-    <singlestore.password>root</singlestore.password>
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>confluent</id>
-      <name>Confluent</name>
-      <url>https://packages.confluent.io/maven/</url>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
-    </repository>
-  </repositories>
-
-  <dependencies>
-    <dependency>
-      <groupId>io.debezium</groupId>
-      <artifactId>debezium-core</artifactId>
-      <version>${version.debezium}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>connect-api</artifactId>
-      <version>${version.kafka}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.singlestore</groupId>
-      <artifactId>singlestore-jdbc-client</artifactId>
-      <version>${version.singlestore.jdbc.driver}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.locationtech.jts.io</groupId>
-      <artifactId>jts-io-common</artifactId>
-      <version>${version.jts.io}</version>
-    </dependency>
-    <!--logging-->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${version.org.slf4j}</version>
-      <optional>true</optional>
-    </dependency>
-    <!-- Testing -->
-    <dependency>
-      <groupId>io.debezium</groupId>
-      <artifactId>debezium-core</artifactId>
-      <version>${version.debezium}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.debezium</groupId>
-      <artifactId>debezium-embedded</artifactId>
-      <version>${version.debezium}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.debezium</groupId>
-      <artifactId>debezium-embedded</artifactId>
-      <version>${version.debezium}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.confluent</groupId>
-      <artifactId>kafka-connect-avro-converter</artifactId>
-      <version>${version.kafka-connect-avro-converter}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>connect-json</artifactId>
-      <version>${version.connect-json}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
-      <version>${version.logback-classic}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <version>${version.testcontainers}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>${version.awaitility}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${version.mockito}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-      <version>${version.junit}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-      <version>${version.assertj-core}</version>
-    </dependency>
-  </dependencies>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
         <configuration>
-          <watchInterval>500</watchInterval>
-          <logDate>default</logDate>
-          <verbose>true</verbose>
           <images>
             <image>
               <!-- A Docker image with SingleStoreDB cluster -->
               <name>${singlestore.image}</name>
               <run>
+                <env>
+                  <ROOT_PASSWORD>${singlestore.password}</ROOT_PASSWORD>
+                  <SINGLESTORE_LICENSE>${singlestore.license}</SINGLESTORE_LICENSE>
+                  <SINGLESTORE_VERSION>${singlestore.version}</SINGLESTORE_VERSION>
+                </env>
                 <namingStrategy>none</namingStrategy>
                 <ports>
                   <port>${singlestore.port}:3306</port>
                 </ports>
-                <env>
-                  <SINGLESTORE_LICENSE>${singlestore.license}</SINGLESTORE_LICENSE>
-                  <ROOT_PASSWORD>${singlestore.password}</ROOT_PASSWORD>
-                  <SINGLESTORE_VERSION>${singlestore.version}</SINGLESTORE_VERSION>
-                </env>
                 <!-- Uncomment this to see database logs in the test output
                 <log>
                     <prefix>SingleStoreDB &gt;&gt;&gt; </prefix>
@@ -234,34 +31,38 @@
                 </log>
                 -->
                 <wait>
-                  <time>300000</time> <!-- 300 seconds max -->
-                  <log>Log Opened</log>
+                  <log>Log Opened</log> <!-- 300 seconds max -->
+                  <time>300000</time>
                 </wait>
               </run>
             </image>
           </images>
+          <logDate>default</logDate>
+          <verbose>true</verbose>
+          <watchInterval>500</watchInterval>
         </configuration>
-        <!--
-        Connect this plugin to the maven lifecycle around the integration-test phase:
-        start the container in pre-integration-test and stop it in post-integration-test.
-        -->
         <executions>
           <execution>
-            <id>start</id>
-            <phase>pre-integration-test</phase>
             <goals>
               <goal>build</goal>
               <goal>start</goal>
             </goals>
+            <id>start</id>
+            <phase>pre-integration-test</phase>
           </execution>
           <execution>
-            <id>stop</id>
-            <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
+            <id>stop</id>
+            <phase>post-integration-test</phase>
           </execution>
         </executions>
+        <!--
+        Connect this plugin to the maven lifecycle around the integration-test phase:
+        start the container in pre-integration-test and stop it in post-integration-test.
+        -->
+        <groupId>io.fabric8</groupId>
       </plugin>
       <!--
       Unlike surefire, the failsafe plugin ensures 'post-integration-test' phase always runs, even
@@ -269,87 +70,85 @@
       after the integration tests (defined as '*IT.java') are run.
       -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>integration-test</id>
-            <goals>
-              <goal>integration-test</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>verify</id>
-            <goals>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
+          <enableAssertions>true</enableAssertions>
           <includes>
             <include>**/*</include>
           </includes>
-          <enableAssertions>true</enableAssertions>
           <systemPropertyVariables>
             <!-- Make these available to the tests via system properties -->
             <singlestore.hostname>${singlestore.host}</singlestore.hostname>
+            <singlestore.password>${singlestore.password}</singlestore.password>
             <singlestore.port>${singlestore.port}</singlestore.port>
             <singlestore.user>${singlestore.user}</singlestore.user>
-            <singlestore.password>${singlestore.password}</singlestore.password>
             <singlestore.version>${singlestore.version}</singlestore.version>
           </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.0.1</version>
         <executions>
           <execution>
-            <phase>verify</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <id>integration-test</id>
+          </execution>
+          <execution>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+            <id>verify</id>
+          </execution>
+        </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <executions>
+          <execution>
             <goals>
               <goal>sign</goal>
             </goals>
+            <phase>verify</phase>
           </execution>
         </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <version>3.0.1</version>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.13</version>
-        <extensions>true</extensions>
+        <configuration>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <serverId>ossrh</serverId>
+          <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
+        </configuration>
         <executions>
           <execution>
             <phase>deploy</phase>
           </execution>
         </executions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-          <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-        </configuration>
+        <extensions>true</extensions>
+        <groupId>org.sonatype.plugins</groupId>
+        <version>1.6.13</version>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
         <configuration>
           <additionalparam>-Xdoclint:none</additionalparam>
         </configuration>
         <executions>
           <execution>
-            <id>attach-javadocs</id>
             <goals>
               <goal>jar</goal>
             </goals>
+            <id>attach-javadocs</id>
           </execution>
         </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <version>2.9.1</version>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
         <executions>
           <execution>
             <!--package phase-->
@@ -358,13 +157,15 @@
             </goals>
           </execution>
         </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <version>3.2.1</version>
       </plugin>
     </plugins>
     <resources>
       <!-- Apply the properties set in the POM to the resource files -->
       <resource>
-        <filtering>true</filtering>
         <directory>src/main/resources</directory>
+        <filtering>true</filtering>
         <includes>
           <include>*</include>
           <include>**/*</include>
@@ -372,46 +173,245 @@
       </resource>
     </resources>
   </build>
+  <dependencies>
+    <dependency>
+      <artifactId>debezium-core</artifactId>
+      <groupId>io.debezium</groupId>
+      <version>${version.debezium}</version>
+    </dependency>
+    <dependency>
+      <artifactId>connect-api</artifactId>
+      <groupId>org.apache.kafka</groupId>
+      <scope>provided</scope>
+      <version>${version.kafka}</version>
+    </dependency>
+    <dependency>
+      <artifactId>singlestore-jdbc-client</artifactId>
+      <groupId>com.singlestore</groupId>
+      <version>${version.singlestore.jdbc.driver}</version>
+    </dependency>
+    <dependency>
+      <artifactId>jts-io-common</artifactId>
+      <groupId>org.locationtech.jts.io</groupId>
+      <version>${version.jts.io}</version>
+    </dependency>
+    <!--logging-->
+    <dependency>
+      <artifactId>slf4j-api</artifactId>
+      <groupId>org.slf4j</groupId>
+      <optional>true</optional>
+      <version>${version.org.slf4j}</version>
+    </dependency>
+    <!-- Testing -->
+    <dependency>
+      <artifactId>debezium-core</artifactId>
+      <groupId>io.debezium</groupId>
+      <scope>test</scope>
+      <type>test-jar</type>
+      <version>${version.debezium}</version>
+    </dependency>
+    <dependency>
+      <artifactId>debezium-embedded</artifactId>
+      <groupId>io.debezium</groupId>
+      <scope>test</scope>
+      <type>test-jar</type>
+      <version>${version.debezium}</version>
+    </dependency>
+    <dependency>
+      <artifactId>debezium-embedded</artifactId>
+      <groupId>io.debezium</groupId>
+      <scope>test</scope>
+      <version>${version.debezium}</version>
+    </dependency>
+    <dependency>
+      <artifactId>kafka-connect-avro-converter</artifactId>
+      <groupId>io.confluent</groupId>
+      <scope>test</scope>
+      <version>${version.kafka-connect-avro-converter}</version>
+    </dependency>
+    <dependency>
+      <artifactId>connect-json</artifactId>
+      <groupId>org.apache.kafka</groupId>
+      <scope>test</scope>
+      <version>${version.connect-json}</version>
+    </dependency>
+    <dependency>
+      <artifactId>logback-classic</artifactId>
+      <groupId>ch.qos.logback</groupId>
+      <scope>test</scope>
+      <version>${version.logback-classic}</version>
+    </dependency>
+    <dependency>
+      <artifactId>testcontainers</artifactId>
+      <groupId>org.testcontainers</groupId>
+      <scope>test</scope>
+      <version>${version.testcontainers}</version>
+    </dependency>
+    <dependency>
+      <artifactId>awaitility</artifactId>
+      <groupId>org.awaitility</groupId>
+      <scope>test</scope>
+      <version>${version.awaitility}</version>
+    </dependency>
+    <dependency>
+      <artifactId>mockito-core</artifactId>
+      <groupId>org.mockito</groupId>
+      <scope>test</scope>
+      <version>${version.mockito}</version>
+    </dependency>
+    <dependency>
+      <artifactId>junit</artifactId>
+      <groupId>junit</groupId>
+      <scope>test</scope>
+      <version>${version.junit}</version>
+    </dependency>
+    <dependency>
+      <artifactId>assertj-core</artifactId>
+      <groupId>org.assertj</groupId>
+      <scope>test</scope>
+      <version>${version.assertj-core}</version>
+    </dependency>
+  </dependencies>
+  <description>SingleStore Debezium Connector</description>
+  <developers>
+    <developer>
+      <email>team@singlestore.com</email>
+      <id>singlestore</id>
+      <name>SingleStore</name>
+      <organization>SingleStore</organization>
+      <organizationUrl>https://www.singlestore.com/</organizationUrl>
+    </developer>
+  </developers>
+  <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+  <groupId>com.singlestore</groupId>
+
+  <licenses>
+    <license>
+      <distribution>repo</distribution>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>singlestore-debezium-connector</name>
+
+  <organization>
+    <name>SingleStore</name>
+    <url>https://www.singlestore.com/</url>
+  </organization>
 
   <profiles>
     <profile>
-      <id>assembly</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>${version.assembly.plugin}</version>
             <dependencies>
               <dependency>
-                <groupId>io.debezium</groupId>
                 <artifactId>debezium-assembly-descriptors</artifactId>
+                <groupId>io.debezium</groupId>
                 <version>${version.debezium}</version>
               </dependency>
             </dependencies>
             <executions>
               <execution>
-                <id>default</id>
-                <phase>package</phase>
+                <configuration>
+                  <attach>true</attach>
+                  <descriptorRefs>
+                    <descriptorRef>connector-distribution</descriptorRef>
+                  </descriptorRefs>  <!-- we want attach & deploy these to Maven -->
+                  <finalName>${project.artifactId}-${project.version}</finalName>
+                  <tarLongFileMode>posix</tarLongFileMode>
+                </configuration>
                 <goals>
                   <goal>single</goal>
                 </goals>
-                <configuration>
-                  <finalName>${project.artifactId}-${project.version}</finalName>
-                  <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
-                  <descriptorRefs>
-                    <descriptorRef>connector-distribution</descriptorRef>
-                  </descriptorRefs>
-                  <tarLongFileMode>posix</tarLongFileMode>
-                </configuration>
+                <id>default</id>
+                <phase>package</phase>
               </execution>
             </executions>
+            <groupId>org.apache.maven.plugins</groupId>
+            <version>${version.assembly.plugin}</version>
           </plugin>
         </plugins>
       </build>
+      <id>assembly</id>
     </profile>
   </profiles>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+
+    <singlestore.host>127.0.0.1</singlestore.host>
+    <singlestore.image>ghcr.io/singlestore-labs/singlestoredb-dev:latest</singlestore.image>
+    <singlestore.license>${env.SINGLESTORE_LICENSE}</singlestore.license>
+    <singlestore.password>root</singlestore.password>
+
+    <singlestore.port>3306</singlestore.port>
+    <singlestore.user>root</singlestore.user>
+    <singlestore.version>8.7.16</singlestore.version>
+    <version.assembly.plugin>3.6.0</version.assembly.plugin>
+    <version.assertj-core>3.11.1</version.assertj-core>
+    <version.awaitility>4.2.0</version.awaitility>
+    <version.connect-json>3.6.1</version.connect-json>
+    <version.debezium>2.5.1.Final</version.debezium>
+    <version.failsafe.plugin>3.2.3</version.failsafe.plugin>
+
+    <version.jts.io>1.19.0</version.jts.io>
+    <version.junit>4.13.2</version.junit>
+
+    <!--
+      Specify the properties that will be used for setting up the integration tests' Docker container.
+      Note that the `dockerhost.ip` property is computed from the IP address of DOCKER_HOST, which will
+      work on all platforms. We'll set some of these as system properties during integration testing.
+    -->
+    <version.kafka>3.6.1</version.kafka>
+    <version.kafka-connect-avro-converter>7.5.1</version.kafka-connect-avro-converter>
+    <version.logback-classic>1.4.14</version.logback-classic>
+    <version.mockito>3.0.0</version.mockito>
+    <version.org.slf4j>2.0.4</version.org.slf4j>
+    <version.singlestore.jdbc.driver>1.2.0</version.singlestore.jdbc.driver>
+    <version.testcontainers>1.19.3</version.testcontainers>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>confluent</id>
+      <name>Confluent</name>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+      </snapshots>
+      <url>https://packages.confluent.io/maven/</url>
+    </repository>
+  </repositories>
+
+  <scm>
+    <connection>scm:git:git@github.com:singlestore-labs/singlestore-debezium-connector.git
+    </connection>
+    <developerConnection>
+      scm:git:git@github.com:singlestore-labs/singlestore-debezium-connector.git
+    </developerConnection>
+    <tag>singlestore-debezium-connector-0.1.7</tag>
+    <url>git://git@github.com:singlestore-labs/singlestore-debezium-connector.git</url>
+  </scm>
+
+  <url>https://github.com/singlestore-labs/singlestore-debezium-connector</url>
+
+  <version>0.1.7</version>
 </project>

--- a/src/main/java/com/singlestore/debezium/SingleStoreChangeRecordEmitter.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreChangeRecordEmitter.java
@@ -26,12 +26,12 @@ public class SingleStoreChangeRecordEmitter extends
   private final OffsetContext offset;
   private final Object[] before;
   private final Object[] after;
-  private final long internalId;
+  private final String internalId;
   private final Table table;
 
   public SingleStoreChangeRecordEmitter(SingleStorePartition partition, OffsetContext offset,
       Clock clock, Operation operation, Object[] before,
-      Object[] after, long internalId, SingleStoreConnectorConfig connectorConfig, Table table) {
+      Object[] after, String internalId, SingleStoreConnectorConfig connectorConfig, Table table) {
     super(partition, offset, clock, connectorConfig);
     this.offset = offset;
     this.operation = operation;

--- a/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
@@ -55,7 +55,7 @@ public class SingleStoreConnection extends JdbcConnection {
 
   private static void validateServerVersion(Statement statement) throws SQLException {
     DatabaseMetaData metaData = (DatabaseMetaData) statement.getConnection().getMetaData();
-    if (metaData.getVersion().versionGreaterOrEqual(8, 7, 16)) {
+    if (!metaData.getVersion().versionGreaterOrEqual(8, 7, 16)) {
       throw new SQLException("The lowest supported version of SingleStore is 8.7.16");
     }
   }

--- a/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
@@ -156,8 +156,14 @@ public class SingleStoreConnection extends JdbcConnection {
    */
   public boolean validateOffset(Set<TableId> tableFilter, SingleStorePartition partition,
       SingleStoreOffsetContext offset) {
-    List<String> offsets = offset.offsets().stream().filter(Objects::nonNull)
-        .map(o -> "'" + o + "'").collect(Collectors.toList());
+    List<String> offsets = offset.offsets().stream()
+        .map(o -> {
+          if (o == null) {
+            return "NULL";
+          } else {
+            return "'" + o + "'";
+          }
+        }).collect(Collectors.toList());
     Optional<String> offsetParam = Optional.of("(" + String.join(",", offsets) + ")");
     final String query = observeQuery(null, tableFilter, Optional.empty(), Optional.empty(),
         offsetParam, Optional.empty());

--- a/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreConnection.java
@@ -1,5 +1,6 @@
 package com.singlestore.debezium;
 
+import com.singlestore.jdbc.DatabaseMetaData;
 import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
@@ -16,7 +17,6 @@ import javax.swing.text.html.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
@@ -54,12 +54,9 @@ public class SingleStoreConnection extends JdbcConnection {
   }
 
   private static void validateServerVersion(Statement statement) throws SQLException {
-    DatabaseMetaData metaData = statement.getConnection().getMetaData();
-    int majorVersion = metaData.getDatabaseMajorVersion();
-    int minorVersion = metaData.getDatabaseMinorVersion();
-    if (majorVersion < 8 || (majorVersion == 8 && minorVersion < 5)) {
-      throw new SQLException(
-          "CDC feature is not supported in a version of SingleStore lower than 8.5");
+    DatabaseMetaData metaData = (DatabaseMetaData) statement.getConnection().getMetaData();
+    if (metaData.getVersion().versionGreaterOrEqual(8, 7, 16)) {
+      throw new SQLException("The lowest supported version of SingleStore is 8.7.16");
     }
   }
 
@@ -359,7 +356,8 @@ public class SingleStoreConnection extends JdbcConnection {
   }
 
   @Override
-  protected List<String> readPrimaryKeyOrUniqueIndexNames(DatabaseMetaData metadata, TableId id)
+  protected List<String> readPrimaryKeyOrUniqueIndexNames(java.sql.DatabaseMetaData metadata,
+      TableId id)
       throws SQLException {
     return readPrimaryKeyNames(metadata, id);
   }

--- a/src/main/java/com/singlestore/debezium/SingleStoreOffsetContext.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreOffsetContext.java
@@ -148,6 +148,7 @@ public class SingleStoreOffsetContext extends CommonOffsetContext<SourceInfo> {
 
   @Override
   public void preSnapshotStart() {
+    sourceInfo.setSnapshot(SnapshotRecord.TRUE);
     snapshotCompleted = false;
   }
 

--- a/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
@@ -153,6 +153,10 @@ public class SingleStoreSnapshotChangeEventSource extends
     TableId table = snapshotContext.capturedTables.iterator().next();
     final String selectStatement = determineSnapshotSelect(snapshotContext, table);
 
+    if (!snapshotContext.offset.isSnapshotRunning()) {
+      snapshotContext.offset.preSnapshotStart();
+    }
+
     doCreateDataEventsForTable(sourceContext, snapshotContext, snapshotContext.offset,
         snapshotReceiver, snapshotContext.tables.forTable(table), selectStatement,
         conn);

--- a/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeEventSource.java
@@ -183,8 +183,7 @@ public class SingleStoreSnapshotChangeEventSource extends
       ResultSet rs = rsWrapper.getResultSet();
       List<Integer> columnPostitions =
           ObserveResultSetUtils
-              .columnPositions(rs, table.columns(),
-                  connectorConfig.populateInternalId());
+              .columnPositions(rs, table.columns());
       long rows = 0;
       Threads.Timer logTimer = getTableScanLogTimer();
 
@@ -197,7 +196,8 @@ public class SingleStoreSnapshotChangeEventSource extends
             ObserveResultSetUtils.internalId(rs),
             ObserveResultSetUtils.partitionId(rs),
             ObserveResultSetUtils.offset(rs),
-            ObserveResultSetUtils.rowToArray(rs, columnPostitions));
+            ObserveResultSetUtils.rowToArray(rs, columnPostitions,
+                connectorConfig.populateInternalId()));
 
         int partitionId = ObserveResultSetUtils.partitionId(rs);
         if (ObserveResultSetUtils.isCommitSnapshot(rs)) {
@@ -206,8 +206,9 @@ public class SingleStoreSnapshotChangeEventSource extends
         } else if (!ObserveResultSetUtils.isBeginSnapshot(rs)
             && !snapshotCommitted.get(partitionId)) {
           rows++;
-          final Object[] row = ObserveResultSetUtils.rowToArray(rs, columnPostitions);
-          final Long internalId = ObserveResultSetUtils.internalId(rs);
+          final Object[] row = ObserveResultSetUtils.rowToArray(rs, columnPostitions,
+              connectorConfig.populateInternalId());
+          final String internalId = ObserveResultSetUtils.internalId(rs);
           if (logTimer.expired()) {
             long stop = clock.currentTimeInMillis();
             LOGGER.info("\t Exported {} records for table '{}' after {}", rows, table.id(),
@@ -258,7 +259,7 @@ public class SingleStoreSnapshotChangeEventSource extends
    */
   protected ChangeRecordEmitter<SingleStorePartition> getChangeRecordEmitter(
       SingleStorePartition partition, SingleStoreOffsetContext offset, TableId tableId, Table table,
-      Object[] row, long internalId, Instant timestamp) {
+      Object[] row, String internalId, Instant timestamp) {
     offset.event(tableId, timestamp);
     return new SingleStoreSnapshotChangeRecordEmitter(partition, offset, row, internalId,
         getClock(), connectorConfig, table);

--- a/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeRecordEmitter.java
+++ b/src/main/java/com/singlestore/debezium/SingleStoreSnapshotChangeRecordEmitter.java
@@ -15,11 +15,11 @@ import org.apache.kafka.connect.data.Struct;
 public class SingleStoreSnapshotChangeRecordEmitter extends
     SnapshotChangeRecordEmitter<SingleStorePartition> {
 
-  private final long internalId;
+  private final String internalId;
   private final Table table;
 
   public SingleStoreSnapshotChangeRecordEmitter(SingleStorePartition partition,
-      OffsetContext offset, Object[] row, long internalId, Clock clock,
+      OffsetContext offset, Object[] row, String internalId, Clock clock,
       RelationalDatabaseConnectorConfig connectorConfig, Table table) {
     super(partition, offset, row, clock, connectorConfig);
     this.internalId = internalId;

--- a/src/main/java/com/singlestore/debezium/util/InternalIdUtils.java
+++ b/src/main/java/com/singlestore/debezium/util/InternalIdUtils.java
@@ -16,7 +16,7 @@ public final class InternalIdUtils {
 
   public static Schema getKeySchema(Table table, TableSchema schema) {
     if (useInternalIdAsKey(table)) {
-      return SchemaBuilder.struct().field(INTERNAL_ID, Schema.INT64_SCHEMA).build();
+      return SchemaBuilder.struct().field(INTERNAL_ID, Schema.STRING_SCHEMA).build();
     } else {
       return schema.keySchema();
     }
@@ -27,7 +27,7 @@ public final class InternalIdUtils {
   }
 
   public static Struct generateKey(Table table, TableSchema tableSchema, Object[] values,
-      Long internalId) {
+      String internalId) {
     if (useInternalIdAsKey(table)) {
       return keyFromInternalId(internalId);
     } else {
@@ -35,9 +35,9 @@ public final class InternalIdUtils {
     }
   }
 
-  private static Struct keyFromInternalId(Long internalId) {
+  private static Struct keyFromInternalId(String internalId) {
     Struct result = new Struct(
-        SchemaBuilder.struct().field(INTERNAL_ID, Schema.INT64_SCHEMA).build());
+        SchemaBuilder.struct().field(INTERNAL_ID, Schema.STRING_SCHEMA).build());
     result.put(INTERNAL_ID, internalId);
     return result;
   }
@@ -47,7 +47,7 @@ public final class InternalIdUtils {
     for (Field f : s.fields()) {
       res.field(f.name(), f.schema());
     }
-    res.field(INTERNAL_ID, Schema.INT64_SCHEMA);
+    res.field(INTERNAL_ID, Schema.STRING_SCHEMA);
 
     return res.optional().build();
   }
@@ -57,19 +57,15 @@ public final class InternalIdUtils {
     result.add(Column.editor()
         .name(INTERNAL_ID)
         .position(result.size() + 1)
-        .type("INT64")
+        .type("TEXT")
         .autoIncremented(false)
         .generated(false)
         .optional(false)
-        .jdbcType(-5)
+        .jdbcType(-1)
         .nativeType(-1)
-        .length(19)
-        .scale(0)
+        .length(16383)
         .create());
 
     return result;
-  }
-
-  private InternalIdUtils() {
   }
 }

--- a/src/main/java/com/singlestore/debezium/util/InternalIdUtils.java
+++ b/src/main/java/com/singlestore/debezium/util/InternalIdUtils.java
@@ -23,8 +23,7 @@ public final class InternalIdUtils {
   }
 
   private static boolean useInternalIdAsKey(Table table) {
-    return table.primaryKeyColumnNames().isEmpty() ||
-        !table.attributeWithName("IS_ROWSTORE").asBoolean();
+    return table.primaryKeyColumnNames().isEmpty();
   }
 
   public static Struct generateKey(Table table, TableSchema tableSchema, Object[] values,

--- a/src/main/java/com/singlestore/debezium/util/ObserveResultSetUtils.java
+++ b/src/main/java/com/singlestore/debezium/util/ObserveResultSetUtils.java
@@ -50,27 +50,11 @@ public final class ObserveResultSetUtils {
   }
 
   public static String offset(ResultSet rs) throws SQLException {
-    return bytesToHex(rs.getBytes(METADATA_COLUMNS[0]));
+    return Utils.bytesToHex(rs.getBytes(METADATA_COLUMNS[0]));
   }
 
   public static Integer partitionId(ResultSet rs) throws SQLException {
     return rs.getInt(METADATA_COLUMNS[1]);
-  }
-
-  private static String bytesToHex(byte[] bytes) {
-    if (bytes == null) {
-      return null;
-    }
-
-    char[] res = new char[bytes.length * 2];
-
-    int j = 0;
-    for (int i = 0; i < bytes.length; i++) {
-      res[j++] = Character.forDigit((bytes[i] >> 4) & 0xF, 16);
-      res[j++] = Character.forDigit((bytes[i] & 0xF), 16);
-    }
-
-    return new String(res);
   }
 
   public static boolean isBeginSnapshot(ResultSet rs) throws SQLException {
@@ -90,7 +74,7 @@ public final class ObserveResultSetUtils {
   }
 
   public static String txId(ResultSet rs) throws SQLException {
-    return bytesToHex(rs.getBytes(METADATA_COLUMNS[4]));
+    return Utils.bytesToHex(rs.getBytes(METADATA_COLUMNS[4]));
   }
 
   public static String txPartitions(ResultSet rs) throws SQLException {
@@ -98,7 +82,7 @@ public final class ObserveResultSetUtils {
   }
 
   public static String internalId(ResultSet rs) throws SQLException {
-    return bytesToHex(rs.getBytes(METADATA_COLUMNS[6]));
+    return Utils.bytesToHex(rs.getBytes(METADATA_COLUMNS[6]));
   }
 
   private ObserveResultSetUtils() {

--- a/src/main/java/com/singlestore/debezium/util/Utils.java
+++ b/src/main/java/com/singlestore/debezium/util/Utils.java
@@ -1,0 +1,24 @@
+package com.singlestore.debezium.util;
+
+public class Utils {
+
+  public static String bytesToHex(byte[] bytes) {
+    if (bytes == null) {
+      return null;
+    }
+
+    char[] res = new char[bytes.length * 2];
+
+    int j = 0;
+    for (int i = 0; i < bytes.length; i++) {
+      res[j++] = Character.forDigit((bytes[i] >> 4) & 0xF, 16);
+      res[j++] = Character.forDigit((bytes[i] & 0xF), 16);
+    }
+
+    return new String(res);
+  }
+
+  public static String escapeString(String s) {
+    return "'" + s.replace("'", "''") + "'";
+  }
+}

--- a/src/test/java/com/singlestore/debezium/IntegrationTestBase.java
+++ b/src/test/java/com/singlestore/debezium/IntegrationTestBase.java
@@ -32,7 +32,7 @@ abstract class IntegrationTestBase extends AbstractConnectorTest {
   static final String TEST_TOPIC_PREFIX = "singlestore_topic";
   private static final String TEST_SERVER_VERSION = System.getProperty("singlestore.version", "");
   private static final String TEST_USER = System.getProperty("singlestore.user", "root");
-  private static final String TEST_PASSWORD = System.getProperty("singlestore.password", "root");
+  private static final String TEST_PASSWORD = "1";
   private static final Logger LOGGER = LoggerFactory.getLogger(IntegrationTestBase.class);
   private static final String TEST_IMAGE = System.getProperty("singlestore.image",
       "ghcr.io/singlestore-labs/singlestoredb-dev:latest");

--- a/src/test/java/com/singlestore/debezium/IntegrationTestBase.java
+++ b/src/test/java/com/singlestore/debezium/IntegrationTestBase.java
@@ -32,7 +32,7 @@ abstract class IntegrationTestBase extends AbstractConnectorTest {
   static final String TEST_TOPIC_PREFIX = "singlestore_topic";
   private static final String TEST_SERVER_VERSION = System.getProperty("singlestore.version", "");
   private static final String TEST_USER = System.getProperty("singlestore.user", "root");
-  private static final String TEST_PASSWORD = "1";
+  private static final String TEST_PASSWORD = System.getProperty("singlestore.password", "root");
   private static final Logger LOGGER = LoggerFactory.getLogger(IntegrationTestBase.class);
   private static final String TEST_IMAGE = System.getProperty("singlestore.image",
       "ghcr.io/singlestore-labs/singlestoredb-dev:latest");

--- a/src/test/java/com/singlestore/debezium/NotificationsIT.java
+++ b/src/test/java/com/singlestore/debezium/NotificationsIT.java
@@ -36,7 +36,9 @@ public class NotificationsIT extends IntegrationTestBase {
   @Before
   public void initTestData() {
     String statements =
-        "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE
+        "DROP TABLE IF EXISTS" + TEST_DATABASE + ".AN;" +
+            "DROP TABLE IF EXISTS" + TEST_DATABASE + ".BN;" +
+            "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE
             + ".AN (pk INT, aa VARCHAR(10), PRIMARY KEY(pk));" +
             "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE + ".BN (aa INT, bb VARCHAR(20));" +
             "DELETE FROM " + TEST_DATABASE + ".AN WHERE 1 = 1;" +

--- a/src/test/java/com/singlestore/debezium/NotificationsIT.java
+++ b/src/test/java/com/singlestore/debezium/NotificationsIT.java
@@ -36,8 +36,8 @@ public class NotificationsIT extends IntegrationTestBase {
   @Before
   public void initTestData() {
     String statements =
-        "DROP TABLE IF EXISTS" + TEST_DATABASE + ".AN;" +
-            "DROP TABLE IF EXISTS" + TEST_DATABASE + ".BN;" +
+        "DROP TABLE IF EXISTS " + TEST_DATABASE + ".AN;" +
+            "DROP TABLE IF EXISTS " + TEST_DATABASE + ".BN;" +
             "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE
             + ".AN (pk INT, aa VARCHAR(10), PRIMARY KEY(pk));" +
             "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE + ".BN (aa INT, bb VARCHAR(20));" +

--- a/src/test/java/com/singlestore/debezium/SingleStoreConnectionIT.java
+++ b/src/test/java/com/singlestore/debezium/SingleStoreConnectionIT.java
@@ -256,8 +256,13 @@ public class SingleStoreConnectionIT extends IntegrationTestBase {
               + "  salary DECIMAL(5,2),"
               + "  bitStr BIT(18)"
               + ")");
-      //3 partitions BeginSnapshot/CommitSnapshot
+      //8 partitions BeginSnapshot/CommitSnapshot
       List<String> expectedTypesOrder = Arrays.asList("BeginSnapshot", "CommitSnapshot",
+          "BeginSnapshot", "CommitSnapshot",
+          "BeginSnapshot", "CommitSnapshot",
+          "BeginSnapshot", "CommitSnapshot",
+          "BeginSnapshot", "CommitSnapshot",
+          "BeginSnapshot", "CommitSnapshot",
           "BeginSnapshot", "CommitSnapshot",
           "BeginSnapshot", "CommitSnapshot",
           "BeginTransaction", "Insert", "CommitTransaction",

--- a/src/test/java/com/singlestore/debezium/SingleStoreDatabaseSchemaIT.java
+++ b/src/test/java/com/singlestore/debezium/SingleStoreDatabaseSchemaIT.java
@@ -52,8 +52,7 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
     try (SingleStoreConnection conn = new SingleStoreConnection(
         defaultJdbcConnectionConfigWithTable("allTypesTable"))) {
       schema.refresh(conn);
-      assertKeySchema("db.allTypesTable", "intColumn",
-          SchemaBuilder.int32().optional().defaultValue(2147483647).build());
+      assertKeySchemaIsInternalId("db.allTypesTable");
     } catch (SQLException e) {
       Assert.fail(e.getMessage());
     }
@@ -62,7 +61,8 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
     try (SingleStoreConnection conn = new SingleStoreConnection(
         defaultJdbcConnectionConfigWithTable("person"))) {
       schema.refresh(conn);
-      assertKeySchemaIsInternalId("db.person");
+      assertKeySchema("db.person", "name",
+          SchemaBuilder.string().build());
     } catch (SQLException e) {
       Assert.fail(e.getMessage());
     }
@@ -165,7 +165,8 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
               .build(), // timestampColumn
           org.apache.kafka.connect.data.Timestamp.builder().optional()
               .defaultValue(Date.from(
-                  LocalDateTime.of(2022, 1, 19, 3, 14, 7).atZone(ZoneId.of("UTC")).toInstant()))
+                  LocalDateTime.of(2022, 1, 19, 3, 14, 7, 111000000).atZone(ZoneId.of("UTC"))
+                      .toInstant()))
               .build(), // timestamp6Column
           Year.builder().optional().defaultValue(1989).build(), // yearColumn
           SchemaBuilder.float64().defaultValue(10000.100001).optional().build(), // decimalColumn
@@ -295,7 +296,7 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
     TableSchema tableSchema = schemaFor(fullyQualifiedTableName);
     Schema keySchema = tableSchema.keySchema();
     assertSchemaContent(keySchema, new String[]{"internalId"},
-        new Schema[]{SchemaBuilder.int64().required().build()});
+        new Schema[]{SchemaBuilder.string().required().build()});
   }
 
   protected void assertKeySchema(String fullyQualifiedTableName, String fields,

--- a/src/test/java/com/singlestore/debezium/SingleStoreDatabaseSchemaIT.java
+++ b/src/test/java/com/singlestore/debezium/SingleStoreDatabaseSchemaIT.java
@@ -44,7 +44,9 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
     try (SingleStoreConnection conn = new SingleStoreConnection(
         defaultJdbcConnectionConfigWithTable("allTypesTable"))) {
       schema.refresh(conn);
-      assertKeySchema("db.allTypesTable");
+      assertSchemaContent(null, null, null);
+      assertKeySchema("db.allTypesTable", "intColumn",
+          SchemaBuilder.int32().optional().defaultValue(2147483647).build());
     } catch (SQLException e) {
       Assert.fail(e.getMessage());
     }
@@ -53,7 +55,7 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
     try (SingleStoreConnection conn = new SingleStoreConnection(
         defaultJdbcConnectionConfigWithTable("person"))) {
       schema.refresh(conn);
-      assertKeySchema("db.person");
+      assertKeySchemaIsInternalId("db.person");
     } catch (SQLException e) {
       Assert.fail(e.getMessage());
     }
@@ -71,8 +73,7 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
           org.apache.kafka.connect.data.Date.builder().optional().build(),
           SchemaBuilder.int32().defaultValue(10).optional().build(),
           SchemaBuilder.float64().optional().build(),
-          Bits.builder(18).optional().build()
-      );
+          Bits.builder(18).optional().build());
     } catch (SQLException e) {
       Assert.fail(e.getMessage());
     }
@@ -83,15 +84,15 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
       schema.refresh(conn);
       assertTablesIncluded("db.product");
       assertTableSchema("db.product", "id, createdByDate, modifiedDate",
-          SchemaBuilder.int64().required().build(),//id
+          SchemaBuilder.int64().required().build(), // id
           org.apache.kafka.connect.data.Timestamp.builder()
               .defaultValue(
                   Date.from(LocalDateTime.of(1970, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC)))
-              .required().build(), //createdByDate epoch timestamp
+              .required().build(), // createdByDate epoch timestamp
           org.apache.kafka.connect.data.Timestamp.builder()
               .defaultValue(
                   Date.from(LocalDateTime.of(1970, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC)))
-              .required().build() //modifiedDate epoch timestamp
+              .required().build() // modifiedDate epoch timestamp
       );
     } catch (SQLException e) {
       Assert.fail(e.getMessage());
@@ -110,78 +111,83 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
               +
               "fixedColumn, numericColumn, charColumn, mediumtextColumn, binaryColumn, varcharColumn, varbinaryColumn, longtextColumn, "
               +
-              "textColumn, tinytextColumn, longblobColumn, mediumblobColumn, blobColumn, tinyblobColumn, jsonColumn, enum_f, set_f, " /* "geographyColumn, "" */
+              "textColumn, tinytextColumn, longblobColumn, mediumblobColumn, blobColumn, tinyblobColumn, jsonColumn, enum_f, set_f, " /*
+                                                                                                                                       * "geographyColumn, "
+                                                                                                                                       * "
+                                                                                                                                       */
               + "geographypointColumn",
-          SchemaBuilder.int16().optional().defaultValue((short) 1).build(), //boolColumn
-          SchemaBuilder.int16().optional().defaultValue((short) 1).build(), //booleanColumn
+          SchemaBuilder.int16().optional().defaultValue((short) 1).build(), // boolColumn
+          SchemaBuilder.int16().optional().defaultValue((short) 1).build(), // booleanColumn
           Bits.builder(64).optional().defaultValue("01234567".getBytes(StandardCharsets.UTF_8))
-              .build(), //bitColumn
-          SchemaBuilder.int16().optional().defaultValue((short) 124).build(), //tinyintColumn
-          SchemaBuilder.int32().optional().defaultValue(8388607).build(), //mediumintColumn
-          SchemaBuilder.int16().optional().defaultValue((short) 32767).build(),//smallintColumn
-          SchemaBuilder.int32().optional().defaultValue(2147483647).build(),//intColumn
-          SchemaBuilder.int32().optional().defaultValue(2147483647).build(),//integerColumn
+              .build(), // bitColumn
+          SchemaBuilder.int16().optional().defaultValue((short) 124).build(), // tinyintColumn
+          SchemaBuilder.int32().optional().defaultValue(8388607).build(), // mediumintColumn
+          SchemaBuilder.int16().optional().defaultValue((short) 32767).build(), // smallintColumn
+          SchemaBuilder.int32().optional().defaultValue(2147483647).build(), // intColumn
+          SchemaBuilder.int32().optional().defaultValue(2147483647).build(), // integerColumn
           SchemaBuilder.int64().optional().defaultValue(9223372036854775807L).build(),
-          //bigintColumn
-          SchemaBuilder.float32().optional().defaultValue(10.1f).build(), //floatColumn
-          SchemaBuilder.float64().optional().defaultValue(100.1).build(), //doubleColumn
-          SchemaBuilder.float64().optional().defaultValue(100.1).build(), //realColumn
+          // bigintColumn
+          SchemaBuilder.float32().optional().defaultValue(10.1f).build(), // floatColumn
+          SchemaBuilder.float64().optional().defaultValue(100.1).build(), // doubleColumn
+          SchemaBuilder.float64().optional().defaultValue(100.1).build(), // realColumn
           org.apache.kafka.connect.data.Date.builder().optional()
               .defaultValue(
                   Date.from(LocalDate.of(2000, 10, 10).atStartOfDay(ZoneId.of("UTC")).toInstant()))
-              .build(), //dateColumn
+              .build(), // dateColumn
           org.apache.kafka.connect.data.Time.builder().optional()
               .defaultValue(
                   java.util.Date.from(LocalDate.EPOCH.atTime(22, 59, 59).toInstant(ZoneOffset.UTC)))
-              .build(),//timeColumn
+              .build(), // timeColumn
           org.apache.kafka.connect.data.Time.builder().optional()
               .defaultValue(java.util.Date.from(
-                  LocalDate.EPOCH.atTime(22, 59, 59, 111111000).toInstant(ZoneOffset.UTC))).build(),
-//time6Column
+                  LocalDate.EPOCH.atTime(22, 59, 59, 111111000).toInstant(ZoneOffset.UTC)))
+              .build(),
+          // time6Column
           org.apache.kafka.connect.data.Timestamp.builder().optional()
               .defaultValue(Date.from(
                   LocalDateTime.of(2023, 12, 31, 23, 59, 59).atZone(ZoneId.of("UTC")).toInstant()))
-              .build(), //datetimeColumn
+              .build(), // datetimeColumn
           org.apache.kafka.connect.data.Timestamp.builder().optional()
               .defaultValue(Date.from(
                   LocalDateTime.of(2023, 12, 31, 22, 59, 59, 111111000).atZone(ZoneId.of("UTC"))
-                      .toInstant())).build(), //datetime6Column
+                      .toInstant()))
+              .build(), // datetime6Column
           org.apache.kafka.connect.data.Timestamp.builder().optional()
               .defaultValue(Date.from(
                   LocalDateTime.of(2022, 1, 19, 3, 14, 7).atZone(ZoneId.of("UTC")).toInstant()))
-              .build(), //timestampColumn
+              .build(), // timestampColumn
           org.apache.kafka.connect.data.Timestamp.builder().optional()
               .defaultValue(Date.from(
                   LocalDateTime.of(2022, 1, 19, 3, 14, 7).atZone(ZoneId.of("UTC")).toInstant()))
-              .build(), //timestamp6Column
-          Year.builder().optional().defaultValue(1989).build(), //yearColumn
-          SchemaBuilder.float64().defaultValue(10000.100001).optional().build(), //decimalColumn
-          SchemaBuilder.float64().defaultValue(10000.0).optional().build(), //decColumn
-          SchemaBuilder.float64().defaultValue(10000.0).optional().build(), //fixedColumn
-          SchemaBuilder.float64().defaultValue(10000.0).optional().build(), //numericColumn
-          SchemaBuilder.string().optional().defaultValue("a").build(), //charColumn
-          SchemaBuilder.string().optional().defaultValue("abc").build(), //mediumtextColumn
+              .build(), // timestamp6Column
+          Year.builder().optional().defaultValue(1989).build(), // yearColumn
+          SchemaBuilder.float64().defaultValue(10000.100001).optional().build(), // decimalColumn
+          SchemaBuilder.float64().defaultValue(10000.0).optional().build(), // decColumn
+          SchemaBuilder.float64().defaultValue(10000.0).optional().build(), // fixedColumn
+          SchemaBuilder.float64().defaultValue(10000.0).optional().build(), // numericColumn
+          SchemaBuilder.string().optional().defaultValue("a").build(), // charColumn
+          SchemaBuilder.string().optional().defaultValue("abc").build(), // mediumtextColumn
           SchemaBuilder.bytes().optional().defaultValue("a".getBytes(StandardCharsets.UTF_8))
-              .build(), //binaryColumn
-          SchemaBuilder.string().optional().defaultValue("abc").build(), //varcharColumn
+              .build(), // binaryColumn
+          SchemaBuilder.string().optional().defaultValue("abc").build(), // varcharColumn
           SchemaBuilder.bytes().optional().defaultValue("abc".getBytes(StandardCharsets.UTF_8))
-              .build(), //varbinaryColumn
-          SchemaBuilder.string().optional().defaultValue("abc").build(), //longtextColumn
-          SchemaBuilder.string().optional().defaultValue("abc").build(), //textColumn
-          SchemaBuilder.string().optional().defaultValue("abc").build(), //tinytextColumn
+              .build(), // varbinaryColumn
+          SchemaBuilder.string().optional().defaultValue("abc").build(), // longtextColumn
+          SchemaBuilder.string().optional().defaultValue("abc").build(), // textColumn
+          SchemaBuilder.string().optional().defaultValue("abc").build(), // tinytextColumn
           SchemaBuilder.bytes().optional().defaultValue("abc".getBytes(StandardCharsets.UTF_8))
-              .build(), //longblobColumn
+              .build(), // longblobColumn
           SchemaBuilder.bytes().optional().defaultValue("abc".getBytes(StandardCharsets.UTF_8))
-              .build(), //mediumblobColumn
+              .build(), // mediumblobColumn
           SchemaBuilder.bytes().optional().defaultValue("abc".getBytes(StandardCharsets.UTF_8))
-              .build(), //blobColumn
+              .build(), // blobColumn
           SchemaBuilder.bytes().optional().defaultValue("abc".getBytes(StandardCharsets.UTF_8))
-              .build(), //tinyblobColumn
-          io.debezium.data.Json.builder().optional().defaultValue("{}").build(), //jsonColumn
-          SchemaBuilder.string().optional().defaultValue("val1").build(), //enum_f
-          SchemaBuilder.string().optional().defaultValue("v1").build(), //set_f
-//                    io.debezium.data.geometry.Geometry.builder().optional().build(),//geographyColumn
-          io.debezium.data.geometry.Geometry.builder().optional().build()//geographypointColumn
+              .build(), // tinyblobColumn
+          io.debezium.data.Json.builder().optional().defaultValue("{}").build(), // jsonColumn
+          SchemaBuilder.string().optional().defaultValue("val1").build(), // enum_f
+          SchemaBuilder.string().optional().defaultValue("v1").build(), // set_f
+          // io.debezium.data.geometry.Geometry.builder().optional().build(),//geographyColumn
+          io.debezium.data.geometry.Geometry.builder().optional().build()// geographypointColumn
       );
     } catch (SQLException e) {
       Assert.fail(e.getMessage());
@@ -209,8 +215,7 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
       assertTablesExcluded("d3.B");
       assertTableSchema("d3.A", "pk, aa",
           SchemaBuilder.int32().required().defaultValue(0).build(),
-          SchemaBuilder.string().optional().build()
-      );
+          SchemaBuilder.string().optional().build());
     } catch (SQLException e) {
       Assert.fail(e.getMessage());
     }
@@ -230,8 +235,7 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
       assertTableSchema("d3.A", "pk, ab, ac",
           SchemaBuilder.int32().required().defaultValue(0).build(),
           SchemaBuilder.float64().optional().build(),
-          SchemaBuilder.string().optional().defaultValue("a").build()
-      );
+          SchemaBuilder.string().optional().defaultValue("a").build());
     } catch (SQLException e) {
       Assert.fail(e.getMessage());
     }
@@ -289,11 +293,18 @@ public class SingleStoreDatabaseSchemaIT extends IntegrationTestBase {
     });
   }
 
-  protected void assertKeySchema(String fullyQualifiedTableName) {
+  protected void assertKeySchemaIsInternalId(String fullyQualifiedTableName) {
     TableSchema tableSchema = schemaFor(fullyQualifiedTableName);
     Schema keySchema = tableSchema.keySchema();
-    assertSchemaContent(keySchema, new String[]{"internalId"},
-        new Schema[]{SchemaBuilder.int64().required().build()});
+    assertSchemaContent(keySchema, new String[] { "internalId" },
+        new Schema[] { SchemaBuilder.int64().required().build() });
+  }
+
+  protected void assertKeySchema(String fullyQualifiedTableName, String fields,
+      Schema... expectedSchemas) {
+    TableSchema tableSchema = schemaFor(fullyQualifiedTableName);
+    Schema keySchema = tableSchema.keySchema();
+    assertSchemaContent(keySchema, fields.split(","), expectedSchemas);
   }
 
   protected void assertTableSchema(String fullyQualifiedTableName, String fields,

--- a/src/test/java/com/singlestore/debezium/SnapshotIT.java
+++ b/src/test/java/com/singlestore/debezium/SnapshotIT.java
@@ -5,10 +5,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.data.SchemaAndValueField;
-import io.debezium.pipeline.notification.channels.SinkNotificationChannel;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,7 +56,7 @@ public class SnapshotIT extends IntegrationTestBase {
     try {
       final SourceRecords recordsA = consumeRecordsByTopic(3);
       final List<SourceRecord> table1 = recordsA.recordsForTopic(
-          TEST_TOPIC_PREFIX + "." + TEST_DATABASE + ".A")
+              TEST_TOPIC_PREFIX + "." + TEST_DATABASE + ".A")
           .stream().sorted(Comparator.comparingInt(
               v -> (Integer) ((Struct) ((Struct) v.value()).get("after")).get("pk")))
           .collect(Collectors.toList());
@@ -72,7 +70,7 @@ public class SnapshotIT extends IntegrationTestBase {
             new SchemaAndValueField("aa", Schema.OPTIONAL_STRING_SCHEMA, "test" + i));
         final Struct key1 = (Struct) record1.key();
         final Struct value1 = (Struct) record1.value();
-        assertEquals(i, key1.get("internalId"));
+        assertEquals(i, key1.get("pk"));
         assertEquals(Schema.Type.STRUCT, key1.schema().type());
         assertEquals(Schema.Type.INT64, key1.schema().fields().get(0).schema().type());
         assertRecord((Struct) value1.get("after"), expectedRow1);
@@ -168,8 +166,8 @@ public class SnapshotIT extends IntegrationTestBase {
                     String.CASE_INSENSITIVE_ORDER))
             .collect(Collectors.toList());
 
-        List<String> values = Arrays.asList(new String[] { "test0", "test1", "test2" });
-        List<String> operations = Arrays.asList(new String[] { "r", "r", "r" });
+        List<String> values = Arrays.asList("test0", "test1", "test2");
+        List<String> operations = Arrays.asList("r", "r", "r");
 
         for (int i = 0; i < records.size(); i++) {
           SourceRecord record = records.get(i);
@@ -188,7 +186,7 @@ public class SnapshotIT extends IntegrationTestBase {
               .stream()
               .map(field -> field.name())
               .collect(Collectors.toSet());
-          assertEquals(new HashSet<>(Arrays.asList("aa")), columnNames);
+          assertEquals(new HashSet<>(List.of("aa")), columnNames);
           assertEquals(values.get(i), value.get("aa"));
         }
       } finally {
@@ -213,7 +211,7 @@ public class SnapshotIT extends IntegrationTestBase {
       assertThat(recordsA.allRecordsInOrder()).isEmpty();
       recordsA = consumeRecordsByTopic(3);
       final List<SourceRecord> table1 = recordsA.recordsForTopic(
-          TEST_TOPIC_PREFIX + "." + TEST_DATABASE + ".A")
+              TEST_TOPIC_PREFIX + "." + TEST_DATABASE + ".A")
           .stream().sorted(Comparator.comparingInt(
               v -> (Integer) ((Struct) ((Struct) v.value()).get("after")).get("pk")))
           .collect(Collectors.toList());
@@ -229,7 +227,7 @@ public class SnapshotIT extends IntegrationTestBase {
         final Struct value1 = (Struct) record1.value();
         assertEquals(i, key1.get("pk"));
         assertEquals(Schema.Type.STRUCT, key1.schema().type());
-        assertEquals(Schema.Type.INT64, key1.schema().fields().get(0).schema().type());
+        assertEquals(Schema.Type.INT32, key1.schema().fields().get(0).schema().type());
         assertRecord((Struct) value1.get("after"), expectedRow1);
         assertThat(record1.sourceOffset())
             .extracting("snapshot").containsExactly(true);

--- a/src/test/java/com/singlestore/debezium/SnapshotIT.java
+++ b/src/test/java/com/singlestore/debezium/SnapshotIT.java
@@ -28,8 +28,8 @@ public class SnapshotIT extends IntegrationTestBase {
   @Before
   public void initTestData() {
     String statements =
-        "DROP TABLE IF EXISTS" + TEST_DATABASE + ".A;" +
-            "DROP TABLE IF EXISTS" + TEST_DATABASE + ".B;" +
+        "DROP TABLE IF EXISTS " + TEST_DATABASE + ".A;" +
+            "DROP TABLE IF EXISTS " + TEST_DATABASE + ".B;" +
             "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE
             + ".A (pk INT, aa VARCHAR(10), PRIMARY KEY(pk));" +
             "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE + ".B (aa INT, bb VARCHAR(20));" +

--- a/src/test/java/com/singlestore/debezium/SnapshotIT.java
+++ b/src/test/java/com/singlestore/debezium/SnapshotIT.java
@@ -28,8 +28,10 @@ public class SnapshotIT extends IntegrationTestBase {
   @Before
   public void initTestData() {
     String statements =
-        "DROP TABLE " + TEST_DATABASE + ".A (pk INT, aa VARCHAR(10), PRIMARY KEY(pk));" +
-            "CREATE TABLE " + TEST_DATABASE + ".A (pk INT, aa VARCHAR(10), PRIMARY KEY(pk));" +
+        "DROP TABLE IF EXISTS" + TEST_DATABASE + ".A;" +
+            "DROP TABLE IF EXISTS" + TEST_DATABASE + ".B;" +
+            "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE
+            + ".A (pk INT, aa VARCHAR(10), PRIMARY KEY(pk));" +
             "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE + ".B (aa INT, bb VARCHAR(20));" +
             "DELETE FROM " + TEST_DATABASE + ".A WHERE pk > -1;" +
             "DELETE FROM " + TEST_DATABASE + ".B WHERE aa > -1;" +

--- a/src/test/java/com/singlestore/debezium/SnapshotIT.java
+++ b/src/test/java/com/singlestore/debezium/SnapshotIT.java
@@ -27,19 +27,20 @@ public class SnapshotIT extends IntegrationTestBase {
 
   @Before
   public void initTestData() {
-    String statements = "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE
-        + ".A (pk INT, aa VARCHAR(10), PRIMARY KEY(pk));" +
-        "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE + ".B (aa INT, bb VARCHAR(20));" +
-        "DELETE FROM " + TEST_DATABASE + ".A WHERE pk > -1;" +
-        "DELETE FROM " + TEST_DATABASE + ".B WHERE aa > -1;" +
-        "INSERT INTO " + TEST_DATABASE + ".B VALUES(0, 'test0');" +
-        "INSERT INTO " + TEST_DATABASE + ".A VALUES(0, 'test0');" +
-        "INSERT INTO " + TEST_DATABASE + ".A VALUES(4, 'test4');" +
-        "INSERT INTO " + TEST_DATABASE + ".A VALUES(1, 'test1');" +
-        "INSERT INTO " + TEST_DATABASE + ".A VALUES(2, 'test2');" +
-        "UPDATE " + TEST_DATABASE + ".B SET bb = 'testUpdated' WHERE aa = 0;" +
-        "DELETE FROM " + TEST_DATABASE + ".A WHERE pk = 4;" +
-        "SNAPSHOT DATABASE " + TEST_DATABASE + ";";
+    String statements =
+        "DROP TABLE " + TEST_DATABASE + ".A (pk INT, aa VARCHAR(10), PRIMARY KEY(pk));" +
+            "CREATE TABLE " + TEST_DATABASE + ".A (pk INT, aa VARCHAR(10), PRIMARY KEY(pk));" +
+            "CREATE TABLE IF NOT EXISTS " + TEST_DATABASE + ".B (aa INT, bb VARCHAR(20));" +
+            "DELETE FROM " + TEST_DATABASE + ".A WHERE pk > -1;" +
+            "DELETE FROM " + TEST_DATABASE + ".B WHERE aa > -1;" +
+            "INSERT INTO " + TEST_DATABASE + ".B VALUES(0, 'test0');" +
+            "INSERT INTO " + TEST_DATABASE + ".A VALUES(0, 'test0');" +
+            "INSERT INTO " + TEST_DATABASE + ".A VALUES(4, 'test4');" +
+            "INSERT INTO " + TEST_DATABASE + ".A VALUES(1, 'test1');" +
+            "INSERT INTO " + TEST_DATABASE + ".A VALUES(2, 'test2');" +
+            "UPDATE " + TEST_DATABASE + ".B SET bb = 'testUpdated' WHERE aa = 0;" +
+            "DELETE FROM " + TEST_DATABASE + ".A WHERE pk = 4;" +
+            "SNAPSHOT DATABASE " + TEST_DATABASE + ";";
     execute(statements);
   }
 

--- a/src/test/java/com/singlestore/debezium/SnapshotIT.java
+++ b/src/test/java/com/singlestore/debezium/SnapshotIT.java
@@ -72,7 +72,7 @@ public class SnapshotIT extends IntegrationTestBase {
         final Struct value1 = (Struct) record1.value();
         assertEquals(i, key1.get("pk"));
         assertEquals(Schema.Type.STRUCT, key1.schema().type());
-        assertEquals(Schema.Type.INT64, key1.schema().fields().get(0).schema().type());
+        assertEquals(Schema.Type.INT32, key1.schema().fields().get(0).schema().type());
         assertRecord((Struct) value1.get("after"), expectedRow1);
         assertThat(record1.sourceOffset())
             .extracting("snapshot").containsExactly(true);
@@ -111,7 +111,7 @@ public class SnapshotIT extends IntegrationTestBase {
       assertNull(value1.get("before"));
       assertNotNull(key1.get("internalId"));
       assertEquals(Schema.Type.STRUCT, key1.schema().type());
-      assertEquals(Schema.Type.INT64, key1.schema().fields().get(0).schema().type());
+      assertEquals(Schema.Type.STRING, key1.schema().fields().get(0).schema().type());
 
     } finally {
       stopConnector();

--- a/src/test/java/com/singlestore/debezium/SnapshotIT.java
+++ b/src/test/java/com/singlestore/debezium/SnapshotIT.java
@@ -58,7 +58,7 @@ public class SnapshotIT extends IntegrationTestBase {
     try {
       final SourceRecords recordsA = consumeRecordsByTopic(3);
       final List<SourceRecord> table1 = recordsA.recordsForTopic(
-              TEST_TOPIC_PREFIX + "." + TEST_DATABASE + ".A")
+          TEST_TOPIC_PREFIX + "." + TEST_DATABASE + ".A")
           .stream().sorted(Comparator.comparingInt(
               v -> (Integer) ((Struct) ((Struct) v.value()).get("after")).get("pk")))
           .collect(Collectors.toList());
@@ -72,14 +72,14 @@ public class SnapshotIT extends IntegrationTestBase {
             new SchemaAndValueField("aa", Schema.OPTIONAL_STRING_SCHEMA, "test" + i));
         final Struct key1 = (Struct) record1.key();
         final Struct value1 = (Struct) record1.value();
-        assertNotNull(key1.get("internalId"));
+        assertEquals(i, key1.get("internalId"));
         assertEquals(Schema.Type.STRUCT, key1.schema().type());
         assertEquals(Schema.Type.INT64, key1.schema().fields().get(0).schema().type());
         assertRecord((Struct) value1.get("after"), expectedRow1);
         assertThat(record1.sourceOffset())
             .extracting("snapshot").containsExactly(true);
-        //              assertThat(record1.sourceOffset())
-        //                        .extracting("snapshot_completed").containsExactly(i == 2);
+        // assertThat(record1.sourceOffset())
+        // .extracting("snapshot_completed").containsExactly(i == 2);
         assertNull(value1.get("before"));
       }
     } finally {
@@ -108,8 +108,8 @@ public class SnapshotIT extends IntegrationTestBase {
       assertRecord((Struct) value1.get("after"), expectedRow1);
       assertThat(record1.sourceOffset())
           .extracting("snapshot").containsExactly(true);
-      //          assertThat(record1.sourceOffset())
-      //                  .extracting("snapshot_completed").containsExactly(false);
+      // assertThat(record1.sourceOffset())
+      // .extracting("snapshot_completed").containsExactly(false);
       assertNull(value1.get("before"));
       assertNotNull(key1.get("internalId"));
       assertEquals(Schema.Type.STRUCT, key1.schema().type());
@@ -168,8 +168,8 @@ public class SnapshotIT extends IntegrationTestBase {
                     String.CASE_INSENSITIVE_ORDER))
             .collect(Collectors.toList());
 
-        List<String> values = Arrays.asList(new String[]{"test0", "test1", "test2"});
-        List<String> operations = Arrays.asList(new String[]{"r", "r", "r"});
+        List<String> values = Arrays.asList(new String[] { "test0", "test1", "test2" });
+        List<String> operations = Arrays.asList(new String[] { "r", "r", "r" });
 
         for (int i = 0; i < records.size(); i++) {
           SourceRecord record = records.get(i);
@@ -213,7 +213,7 @@ public class SnapshotIT extends IntegrationTestBase {
       assertThat(recordsA.allRecordsInOrder()).isEmpty();
       recordsA = consumeRecordsByTopic(3);
       final List<SourceRecord> table1 = recordsA.recordsForTopic(
-              TEST_TOPIC_PREFIX + "." + TEST_DATABASE + ".A")
+          TEST_TOPIC_PREFIX + "." + TEST_DATABASE + ".A")
           .stream().sorted(Comparator.comparingInt(
               v -> (Integer) ((Struct) ((Struct) v.value()).get("after")).get("pk")))
           .collect(Collectors.toList());
@@ -227,7 +227,7 @@ public class SnapshotIT extends IntegrationTestBase {
             new SchemaAndValueField("aa", Schema.OPTIONAL_STRING_SCHEMA, "test" + i));
         final Struct key1 = (Struct) record1.key();
         final Struct value1 = (Struct) record1.value();
-        assertNotNull(key1.get("internalId"));
+        assertEquals(i, key1.get("pk"));
         assertEquals(Schema.Type.STRUCT, key1.schema().type());
         assertEquals(Schema.Type.INT64, key1.schema().fields().get(0).schema().type());
         assertRecord((Struct) value1.get("after"), expectedRow1);
@@ -277,8 +277,8 @@ public class SnapshotIT extends IntegrationTestBase {
           for (int i = 0; i < records.size(); i++) {
             SourceRecord record = records.get(i);
             Struct key = (Struct) record.key();
-            assertEquals(key.getInt32("a"), keyA.get(i));
-            assertEquals(key.getString("b"), keyB.get(i));
+            assertEquals(keyA.get(i), key.getInt32("a"));
+            assertEquals(keyB.get(i), key.getString("b"));
           }
         } finally {
           stopConnector();

--- a/src/test/java/com/singlestore/debezium/StreamingIT.java
+++ b/src/test/java/com/singlestore/debezium/StreamingIT.java
@@ -43,7 +43,7 @@ public class StreamingIT extends IntegrationTestBase {
         conn.execute("INSERT INTO `allTypesTable` VALUES (\n" + "TRUE, " + // boolColumn
             "TRUE, " + // booleanColumn
             "'abcdefgh', " + // bitColumn
-            "-128, " +  // tinyintColumn
+            "-128, " + // tinyintColumn
             "-8388608, " + // mediumintColumn
             "-32768, " + // smallintColumn
             "-2147483648, " + // intColumn
@@ -57,28 +57,28 @@ public class StreamingIT extends IntegrationTestBase {
             // It is converted to 24h - time during reading of the result
             "'0:00:00', " + // timeColumn
             "'0:00:00.000000', " + // time6Column
-            "'1000-01-01 00:00:00', " +  // datetimeColumn
+            "'1000-01-01 00:00:00', " + // datetimeColumn
             "'1000-01-01 00:00:00.000000', " + // datetime6Column
-            "'1970-01-01 00:00:01', " +  // timestampColumn
-            "'1970-01-01 00:00:01.000000', " +  // timestamp6Column
-            "1901, " +  // yearColumn
+            "'1970-01-01 00:00:01', " + // timestampColumn
+            "'1970-01-01 00:00:01.000000', " + // timestamp6Column
+            "1901, " + // yearColumn
             "12345678901234567890123456789012345.123456789012345678901234567891, " +
             // decimalColumn
             "1234567890, " + // decColumn
             "1234567890, " + // fixedColumn
-            "1234567890, " +  // numericColumn
+            "1234567890, " + // numericColumn
             "'a', " + // charColumn
-            "'abc', " +  // mediumtextColumn
+            "'abc', " + // mediumtextColumn
             "'a', " + // binaryColumn
-            "'abc', " +  // varcharColumn
-            "'abc', " +  // varbinaryColumn
-            "'abc', " +  // longtextColumn
-            "'abc', " +  // textColumn
-            "'abc', " +  // tinytextColumn
-            "'abc', " +  // longblobColumn
-            "'abc', " +  // mediumblobColumn
-            "'abc', " +  // blobColumn
-            "'abc', " +  // tinyblobColumn
+            "'abc', " + // varcharColumn
+            "'abc', " + // varbinaryColumn
+            "'abc', " + // longtextColumn
+            "'abc', " + // textColumn
+            "'abc', " + // tinytextColumn
+            "'abc', " + // longblobColumn
+            "'abc', " + // mediumblobColumn
+            "'abc', " + // blobColumn
+            "'abc', " + // tinyblobColumn
             "'{}', " + // jsonColumn
             "'val1', " + // enum_f
             "'v1', " + // set_f
@@ -268,7 +268,7 @@ public class StreamingIT extends IntegrationTestBase {
           }
 
           Struct key = (Struct) record.key();
-          ids.add(key.getInt64("internalId"));
+          ids.add(key.getInt64("id"));
         }
 
         assertEquals(ids.get(0), ids.get(3));
@@ -435,8 +435,7 @@ public class StreamingIT extends IntegrationTestBase {
             "SET GLOBAL snapshots_to_keep=1",
             "SET GLOBAL snapshot_trigger_size=65536",
             "CREATE TABLE IF NOT EXISTS staleOffsets(a INT)",
-            "DELETE FROM staleOffsets WHERE 1 > 0"
-        );
+            "DELETE FROM staleOffsets WHERE 1 > 0");
 
         Configuration config = defaultJdbcConfigWithTable("staleOffsets").edit()
             .withDefault("offset.flush.interval.ms", "20").build();
@@ -478,8 +477,7 @@ public class StreamingIT extends IntegrationTestBase {
         }
       } finally {
         conn.execute("SET GLOBAL snapshots_to_keep=2",
-            "SET GLOBAL snapshot_trigger_size=2147483648"
-        );
+            "SET GLOBAL snapshot_trigger_size=2147483648");
         stopConnector();
       }
     }
@@ -524,8 +522,8 @@ public class StreamingIT extends IntegrationTestBase {
           for (int i = 0; i < records.size(); i++) {
             SourceRecord record = records.get(i);
             Struct key = (Struct) record.key();
-            assertEquals(key.getInt32("a"), keyA.get(i));
-            assertEquals(key.getString("b"), keyB.get(i));
+            assertEquals(keyA.get(i), key.getInt32("a"));
+            assertEquals(keyB.get(i), key.getString("b"));
           }
         } finally {
           stopConnector();
@@ -573,8 +571,8 @@ public class StreamingIT extends IntegrationTestBase {
           for (int i = 0; i < records.size(); i++) {
             SourceRecord record = records.get(i);
             Struct key = (Struct) record.key();
-            assertEquals(key.getInt32("a"), keyA.get(i));
-            assertEquals(key.getString("b"), keyB.get(i));
+            assertEquals(keyA.get(i), key.getInt32("a"));
+            assertEquals(keyB.get(i), key.getString("b"));
           }
         } finally {
           stopConnector();
@@ -583,7 +581,8 @@ public class StreamingIT extends IntegrationTestBase {
     }
   }
 
-  //Offset is validated successfully and offset is not reset, streaming should proceed after connector is restarted
+  // Offset is validated successfully and offset is not reset, streaming should
+  // proceed after connector is restarted
   @Test
   public void testValidOffsetInWhenNeededSnapshotMode() throws Exception {
     String table = "validOffsets1";
@@ -591,8 +590,7 @@ public class StreamingIT extends IntegrationTestBase {
         defaultJdbcConnectionConfig())) {
       conn.execute(String.format("USE %s", TEST_DATABASE),
           String.format("DROP TABLE IF EXISTS %s", table),
-          String.format("CREATE TABLE %s(a INT)", table)
-      );
+          String.format("CREATE TABLE %s(a INT)", table));
       Configuration config = defaultJdbcConfigWithTable(table).edit()
           .withDefault(SingleStoreConnectorConfig.SNAPSHOT_MODE,
               SingleStoreConnectorConfig.SnapshotMode.WHEN_NEEDED)
@@ -622,7 +620,7 @@ public class StreamingIT extends IntegrationTestBase {
       Thread.sleep(100);
       records = consumeRecordsByTopic(10).allRecordsInOrder();
       assertEquals(10, records.size());
-      //expected offset is not reset and stream type records are consumed
+      // expected offset is not reset and stream type records are consumed
       assertNotNull("must be a stream type record",
           records.get(0).sourceOffset().get("snapshot_completed"));
       assertTrue("must be a stream type record",
@@ -632,7 +630,8 @@ public class StreamingIT extends IntegrationTestBase {
     }
   }
 
-  //Offset is failed to validate and reset, after connector is restarted snapshot reading should be executed
+  // Offset is failed to validate and reset, after connector is restarted snapshot
+  // reading should be executed
   @Test
   public void testStaleOffsetInWhenNeededSnapshotMode() throws Exception {
     String table = "staleOffsets2";
@@ -643,8 +642,7 @@ public class StreamingIT extends IntegrationTestBase {
             "SET GLOBAL snapshots_to_keep=1",
             "SET GLOBAL snapshot_trigger_size=65536",
             String.format("DROP TABLE IF EXISTS %s", table),
-            String.format("CREATE TABLE %s(a INT)", table)
-        );
+            String.format("CREATE TABLE %s(a INT)", table));
         Configuration config = defaultJdbcConfigWithTable(table).edit()
             .withDefault(OFFSET_FLUSH_INTERVAL_MS, 20)
             .withDefault(SingleStoreConnectorConfig.SNAPSHOT_MODE,
@@ -675,15 +673,14 @@ public class StreamingIT extends IntegrationTestBase {
 
         Thread.sleep(1000);
         records = consumeRecordsByTopic(10000).allRecordsInOrder();
-        //expected offset is reset and snapshot type records are consumed
+        // expected offset is reset and snapshot type records are consumed
         assertNotNull("must be a snapshot type record",
             records.get(0).sourceOffset().get("snapshot"));
         assertTrue("must be a snapshot type record",
             Boolean.parseBoolean(records.get(0).sourceOffset().get("snapshot").toString()));
       } finally {
         conn.execute("SET GLOBAL snapshots_to_keep=2",
-            "SET GLOBAL snapshot_trigger_size=2147483648"
-        );
+            "SET GLOBAL snapshot_trigger_size=2147483648");
         stopConnector();
       }
     }

--- a/src/test/java/com/singlestore/debezium/StreamingIT.java
+++ b/src/test/java/com/singlestore/debezium/StreamingIT.java
@@ -468,7 +468,7 @@ public class StreamingIT extends IntegrationTestBase {
 
         stopConnector();
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 80000; i++) {
           conn.execute("INSERT INTO staleOffsets VALUES (123456789)");
         }
 
@@ -677,7 +677,7 @@ public class StreamingIT extends IntegrationTestBase {
         stopConnector();
 
         Thread.sleep(100);
-        for (int i = 10; i < 20000; i++) {
+        for (int i = 10; i < 80010; i++) {
           conn.execute(String.format("INSERT INTO %s VALUES (%s)", table, i));
         }
         Thread.sleep(100);
@@ -685,7 +685,8 @@ public class StreamingIT extends IntegrationTestBase {
         assertConnectorIsRunning();
 
         Thread.sleep(1000);
-        records = consumeRecordsByTopic(20000).allRecordsInOrder();
+        records = consumeRecordsByTopic(80000).allRecordsInOrder();
+        assertEquals(80000, records.size());
         // expected offset is reset and snapshot type records are consumed
         assertNotNull("must be a snapshot type record",
             records.get(0).sourceOffset().get("snapshot"));

--- a/src/test/java/com/singlestore/debezium/StreamingIT.java
+++ b/src/test/java/com/singlestore/debezium/StreamingIT.java
@@ -699,7 +699,7 @@ public class StreamingIT extends IntegrationTestBase {
         stopConnector();
 
         Thread.sleep(100);
-        for (int i = 10; i < 40010; i++) {
+        for (int i = 10; i < 80010; i++) {
           conn.execute(String.format("INSERT INTO %s VALUES (%s)", table, i));
         }
         conn.execute(String.format("SNAPSHOT DATABASE %s", TEST_DATABASE));
@@ -707,8 +707,8 @@ public class StreamingIT extends IntegrationTestBase {
         start(SingleStoreConnector.class, config);
         assertConnectorIsRunning();
 
-        records = consumeRecordsByTopic(40000).allRecordsInOrder();
-        assertEquals(40000, records.size());
+        records = consumeRecordsByTopic(80000).allRecordsInOrder();
+        assertEquals(80000, records.size());
         // expected offset is reset and snapshot type records are consumed
         assertNotNull("must be a snapshot type record",
             records.get(0).sourceOffset().get("snapshot"));

--- a/src/test/java/com/singlestore/debezium/StreamingIT.java
+++ b/src/test/java/com/singlestore/debezium/StreamingIT.java
@@ -699,16 +699,16 @@ public class StreamingIT extends IntegrationTestBase {
         stopConnector();
 
         Thread.sleep(100);
-        for (int i = 10; i < 80010; i++) {
+        for (int i = 10; i < 40010; i++) {
           conn.execute(String.format("INSERT INTO %s VALUES (%s)", table, i));
         }
-        Thread.sleep(100);
+        conn.execute(String.format("SNAPSHOT DATABASE %s", TEST_DATABASE));
+        Thread.sleep(1000);
         start(SingleStoreConnector.class, config);
         assertConnectorIsRunning();
 
-        Thread.sleep(1000);
-        records = consumeRecordsByTopic(80000).allRecordsInOrder();
-        assertEquals(80000, records.size());
+        records = consumeRecordsByTopic(40000).allRecordsInOrder();
+        assertEquals(40000, records.size());
         // expected offset is reset and snapshot type records are consumed
         assertNotNull("must be a snapshot type record",
             records.get(0).sourceOffset().get("snapshot"));

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -9,11 +9,11 @@
     </layout>
   </appender>
 
-  <logger name="com.singlestore.debezium" level="trace" additivity="false">
+  <logger name="com.singlestore.debezium" level="debug" additivity="false">
     <appender-ref ref="CONSOLE"/>
   </logger>
 
-  <logger name="io.debezium" level="trace" additivity="false">
+  <logger name="io.debezium" level="debug" additivity="false">
     <appender-ref ref="CONSOLE"/>
   </logger>
   <!--


### PR DESCRIPTION
In the 8.7.16 version of S2, if the table has PK, internalId is not populated.
 * Changed to populate PK instead of InternalId if the table has it
 * Changed the type of the InternalId field (starting from 8.7.16 it is returned as bytes)
 * Fixed offset validation for when_needed mode (used offset table instead of just running an observe query)
 * Fixed setting of information if the record is part of the snapshot when the snapshot is retaken
 * Fixed tests
 * Changed log level for tests as verbose logs caused OOM errors in the CI
 * Changed lowest supported version to 8.7.16
