### PR TITLE
Fixed BIT type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
     <version.logback-classic>1.4.14</version.logback-classic>
     <version.mockito>3.0.0</version.mockito>
     <version.org.slf4j>2.0.4</version.org.slf4j>
-    <version.singlestore.jdbc.driver>1.2.0</version.singlestore.jdbc.driver>
+    <version.singlestore.jdbc.driver>1.2.5</version.singlestore.jdbc.driver>
     <version.testcontainers>1.19.3</version.testcontainers>
   </properties>
 

--- a/src/test/java/com/singlestore/debezium/StreamingIT.java
+++ b/src/test/java/com/singlestore/debezium/StreamingIT.java
@@ -102,8 +102,7 @@ public class StreamingIT extends IntegrationTestBase {
         // TODO: PLAT-6909 handle BOOL columns as boolean
         assertEquals((short) 1, after.get("boolColumn"));
         assertEquals((short) 1, after.get("booleanColumn"));
-        // TODO: PLAT-6910 BIT type is returned in reversed order
-        assertArrayEquals("hgfedcba".getBytes(), (byte[]) after.get("bitColumn"));
+        assertArrayEquals("abcdefgh".getBytes(), (byte[]) after.get("bitColumn"));
         assertEquals((short) -128, after.get("tinyintColumn"));
         assertEquals(-8388608, after.get("mediumintColumn"));
         assertEquals((short) -32768, after.get("smallintColumn"));


### PR DESCRIPTION
In the old JDBC driver by default BIT was returned in the reversed order.