### PR TITLE
Removed publishing of the test report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,6 @@ jobs:
           SINGLESTORE_USER: ${{ secrets.SINGLESTORE_USER }}
           SINGLESTORE_PASSWORD: ${{ secrets.SINGLESTORE_PASSWORD }}
           SINGLESTORE_PORT: ${{ secrets.SINGLESTORE_PORT }}
-      - name: Publish Test Report
-        if: success() || failure()
-        uses: scacap/action-surefire-report@v1.7.3
-        with:
-          report_paths: '**/**-reports/TEST-*.xml'
-          check_name: 'Test Report ${{ matrix.singlestore_version }}'
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph


### PR DESCRIPTION
As third-party GH actions usage is now restricted, remove unnecessary steps that use them. 